### PR TITLE
Added StatusLine plugin

### DIFF
--- a/_plugins/status_line.md
+++ b/_plugins/status_line.md
@@ -1,0 +1,29 @@
+---
+layout: plugin
+
+id: status_line
+title: StatusLine
+description: Display M117 (Display Message) in the SideBar
+author: Philippe Vanhaesendonck
+license: AGPLv3
+
+date: 2015-07-04
+
+homepage: https://github.com/AmedeeBulle/StatusLine
+source: https://github.com/AmedeeBulle/StatusLine
+archive: https://github.com/AmedeeBulle/StatusLine/archive/master.zip
+
+follow_dependency_links: false
+
+tags:
+- ui
+
+compatibility:
+  octoprint:
+  - 1.2.0
+
+---
+
+(Very) simple plugin to which displays the M117 command (Display Message) in the SideBar.
+
+![SiteBar](https://raw.githubusercontent.com/AmedeeBulle/StatusLine/master/status_line.png)


### PR DESCRIPTION
Very simple plugin to show the controller status line (M117 commands) in the SideBar.