### PR TITLE
Updating Octoslack license from Apache2 to MIT

### DIFF
--- a/_plugins/Octoslack.md
+++ b/_plugins/Octoslack.md
@@ -5,7 +5,7 @@ id: Octoslack
 title: Octoslack
 description: An OctoPrint plugin for monitoring your printer and prints via Slack or Mattermost
 author: Chris Fraschetti
-license: Apache2
+license: MIT
 
 # today's date in format YYYY-MM-DD, e.g.
 date: 2017-05-20


### PR DESCRIPTION
The code and git licenses were out of sync but are now both MIT