### PR TITLE
PolarCloud plugin needs a later version of OctoPrint

### DIFF
--- a/_plugins/polarcloud.md
+++ b/_plugins/polarcloud.md
@@ -32,6 +32,10 @@ screenshots:
 
 featuredimage: /assets/img/plugins/polarcloud/polarcloud.png
 
+compatibility:
+  octoprint:
+  - 1.3.4
+
 ---
 ## Easily Monitor Your Prints from Anywhere
 


### PR DESCRIPTION
It uses the client API as well as newer event types.