### PR TITLE
Add note to m84 plugin about lack of visible UI changes

### DIFF
--- a/_plugins/m84motoff.md
+++ b/_plugins/m84motoff.md
@@ -25,6 +25,6 @@ tags:
 
 ---
     
-A plugin to intercept the gcode command M18 during the queueing stage and rewrite it as M84 before sending it to the printer (for compatibility with the Repetier line of firmware).
+A plugin to intercept the gcode command ```M18``` during the queueing stage and rewrite it as ```M84``` before sending it to the printer (for compatibility with the Repetier line of firmware).
 
-Note: Because this plugin intercepts the code during the queueing stage, that also includes manual gcode entry. Entering M18 in the terminal tab will also result in it being send to the printer as M84.
+Note: Because this plugin intercepts the code during the queueing stage, that also includes manual gcode entry. Entering ```M18``` in the terminal tab will also result in it being send to the printer as ```M84```, and as this plugin works in OctoPrint's server back end, no visible UI changes or settings are present.


### PR DESCRIPTION
Additional information that the plugin makes no visible UI changes. I've also wrapped the M18 and M84 code in code fences for easier readability.

r.e. Discussion here: https://discourse.octoprint.org/t/duplicate-plugins/396 that it might be relevant to let users know there's no visible changes made by this plugin.

