### PR TITLE
signal_notifier: abbreviate summary and mention signal-cli requirement

### DIFF
--- a/_plugins/signalnotifier.md
+++ b/_plugins/signalnotifier.md
@@ -3,7 +3,7 @@ layout: plugin
 
 id: signalnotifier
 title: OctoPrint_Signal-Notifier
-description: Octoprint plugin for print completion notifications using Signal.
+description: Print completion notifications using Signal. Requires signal-cli.
 author: Andrew Erickson
 license: AGPLv3
 


### PR DESCRIPTION
I received a issue asking if signal-cli is required and noticed it's not mentioned in the plugin manager inside the app (only on github and the plugin webpage). This fixes that.

Thanks. :)