### PR TITLE
polarcloud: remove follow-dependency-links

### DIFF
--- a/_plugins/polarcloud.md
+++ b/_plugins/polarcloud.md
@@ -15,7 +15,7 @@ archive: https://github.com/markwal/OctoPrint-PolarCloud/archive/master.zip
 
 # Set this to true if your plugin uses the dependency_links setup parameter to include
 # library versions not yet published on PyPi. SHOULD ONLY BE USED IF THERE IS NO OTHER OPTION!
-follow_dependency_links: true
+follow_dependency_links: false
 
 tags:
 - cloud


### PR DESCRIPTION
The newest pip removed support for follow-dependency-links.  While this will break the plugin install on octopi 0.13, we're working on a workaround for those folks (likely includes asking them to update pip).