### PR TITLE
Add new plugin "PauseForUserEvent"

### DIFF
--- a/_plugins/PauseForUserEvent.md
+++ b/_plugins/PauseForUserEvent.md
@@ -16,7 +16,7 @@ tags:
 compatibility:
   octoprint:
   - 1.3.11 
-date: 2019-06-03
+date: 2019-06-11
 
 ---
 

--- a/_plugins/PauseForUserEvent.md
+++ b/_plugins/PauseForUserEvent.md
@@ -2,7 +2,7 @@
 layout: plugin
 id: PauseForUserEvent
 title: PauseForUserEvent
-description: Adds a new event 'paused_for_user' when the printer needs manual intervention (signalled by sending "echo:busy: paused for user")
+description: Adds a new event 'paused_for_user' when the printer needs manual intervention
 author: Thomas Arthofer
 license: AGPLv3
 homepage: https://github.com/zeroflow/OctoPrint-PauseForUserEvent

--- a/_plugins/PauseForUserEvent.md
+++ b/_plugins/PauseForUserEvent.md
@@ -1,7 +1,7 @@
 ---
 layout: plugin
-id: PauseForUserEvent
-title: PauseForUserEvent
+id: pause_for_user_event
+title: PauseForUser Event
 description: Adds a new event 'paused_for_user' when the printer needs manual intervention
 author: Thomas Arthofer
 license: AGPLv3

--- a/_plugins/PauseForUserEvent.md
+++ b/_plugins/PauseForUserEvent.md
@@ -1,0 +1,26 @@
+---
+layout: plugin
+id: PauseForUserEvent
+title: PauseForUserEvent
+description: Adds a new event 'paused_for_user' when the printer needs manual intervention (signalled by sending "echo:busy: paused for user")
+author: Thomas Arthofer
+license: AGPLv3
+homepage: https://github.com/zeroflow/OctoPrint-PauseForUserEvent
+source: https://github.com/zeroflow/OctoPrint-PauseForUserEvent
+archive: https://github.com/zeroflow/OctoPrint-PauseForUserEvent/archive/master.zip
+tags: 
+- paused for user
+- Prusa MMU2
+- notification
+- event
+compatibility:
+  octoprint:
+  - 1.3.5
+date: 2019-06-03
+
+---
+
+When `echo:busy: paused for user` is received on the serial port, this plugin then raises a `paused_for_user` event, which may then be used with other plugins like [OctoPrint-MQTT](https://github.com/OctoPrint/OctoPrint-MQTT) to alert the user, that the printer needs attention.
+The primary use for this is the Prusa MMU2S, which when it fails to load/unload filament, will halt the printer and send this message on serial.
+
+See the plugin's [README](https://github.com/zeroflow/OctoPrint-PauseForUserEvent) for details.

--- a/_plugins/PauseForUserEvent.md
+++ b/_plugins/PauseForUserEvent.md
@@ -15,7 +15,7 @@ tags:
 - event
 compatibility:
   octoprint:
-  - 1.3.5
+  - 1.3.11 
 date: 2019-06-03
 
 ---


### PR DESCRIPTION
This new plugin adds a new event "paused_for_user" in case 'echo:busy: paused for user' is received on serial
This can be used to forward this event via MQTT to a mobile phone so the user knows that the printer needs manual intervention.

The usecase is the Prusa MMU2.
In case the loading/unloading procedure goes wrong, it then just keeps sending `echo:busy: paused for user` until the user fixes the issue and presses the button on the LCD.

Currently, the user receives no notification here as OctoPrint nicely waits for the printer to signal it's readiness again.