### PR TITLE
A Dashboard tab for Octoprint

### DIFF
--- a/_plugins/dashboard.md
+++ b/_plugins/dashboard.md
@@ -7,7 +7,7 @@ description: A dashboard tab for Octoprint
 author: Stefan Cohen
 license: AGPLv3
 
-date: 2019-09-11
+date: 2019-09-10
 
 homepage: https://github.com/StefanCohen/OctoPrint-Dashboard
 source: https://github.com/StefanCohen/OctoPrint-Dashboard
@@ -20,22 +20,22 @@ tags:
 - progress
 
 screenshots:
-- url: https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot.png
+- url: https://github.com/StefanCohen/OctoPrint-Dashboard/raw/master/screenshot.png
   alt: screenshot
   caption: caption of a screenshot
-- url: https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot-theme.png
+- url: https://github.com/StefanCohen/OctoPrint-Dashboard/raw/master/screenshot-theme.png
   alt: screenshot
   caption: themed screenshot
-- url: https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot-theme2.png
+- url: https://github.com/StefanCohen/OctoPrint-Dashboard/raw/master/screenshot-theme2.png
   alt: screenshot
   caption: themed screenshot
 
-featuredimage: https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot.png
+featuredimage: https://github.com/StefanCohen/OctoPrint-Dashboard/raw/master/screenshot.png
 
 ---
 This plugin adds a  dashboard tab in Octoprint that displays the most relevant info regarding the state of the printer and any on-going print job.
 
-![Screenshot](https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot.png)
+![Screenshot](https://github.com/StefanCohen/OctoPrint-Dashboard/raw/master/screenshot.png)
 
 ## Features
 
@@ -54,7 +54,7 @@ This plugin adds a  dashboard tab in Octoprint that displays the most relevant i
 * Uses GCode analysis provided by [DisplayLayerProgress](https://plugins.octoprint.org/plugins/DisplayLayerProgress/) to get more accurate layer and fan data
 * Theme friendly:
 
-![Screenshot](https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot-theme.png)
+![Screenshot](https://github.com/StefanCohen/OctoPrint-Dashboard/raw/master/screenshot-theme.png)
 
 
 For installation and configuration details, please visit the [dashboard github page](https://github.com/StefanCohen/OctoPrint-Dashboard) 

--- a/_plugins/dashboard.md
+++ b/_plugins/dashboard.md
@@ -2,16 +2,12 @@
 layout: plugin
 
 id: dashboard
-layout: plugin
-
-id: dashboard
 title: OctoPrint-Dashboard
 description: A dashboard tab for Octoprint
 author: Stefan Cohen
 license: AGPLv3
 
-# today's date in format YYYY-MM-DD, e.g.
-date: 2019-09-10
+date: 2019-09-11
 
 homepage: https://github.com/StefanCohen/OctoPrint-Dashboard
 source: https://github.com/StefanCohen/OctoPrint-Dashboard
@@ -21,6 +17,7 @@ tags:
 - dashboard
 - status
 - overview
+- progress
 
 screenshots:
 - url: https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot.png
@@ -30,8 +27,34 @@ screenshots:
   alt: screenshot
   caption: themed screenshot
 - url: https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot-theme2.png
+  alt: screenshot
+  caption: themed screenshot
 
 featuredimage: https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot.png
 
 ---
-This plugin adds a  dashboard tab in Octoprint that displays the most relevant info regarding the state of the printer and any on-going print jobs.
+This plugin adds a  dashboard tab in Octoprint that displays the most relevant info regarding the state of the printer and any on-going print job.
+
+![Screenshot](https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot.png)
+
+## Features
+
+* Shows stats for:
+    * Printer profile, Connection status, Printer Status
+    * Hotend temp(s), Bed Temp, Chamber Temp, Fan speed
+    * Printed file, Progress
+    * Estimated total time, Elapsed time, Estimated time left
+    * Current layer, Total layers
+    * Current height, Total height
+    * Average layer time
+* Supports multiple hotends as configured in the printer profile
+* Supports chamber temperature if configured in the printer profile
+* Configurable progress gauge type (Circle, Bar)
+* Uses Estimates from [PrintTimeGenius](https://plugins.octoprint.org/plugins/PrintTimeGenius/) when installed
+* Uses GCode analysis provided by [DisplayLayerProgress](https://plugins.octoprint.org/plugins/DisplayLayerProgress/) to get more accurate layer and fan data
+* Theme friendly:
+
+![Screenshot](https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot-theme.png)
+
+
+For installation and configuration details, please visit the [dashboard github page](https://github.com/StefanCohen/OctoPrint-Dashboard) 

--- a/_plugins/dashboard.md
+++ b/_plugins/dashboard.md
@@ -1,0 +1,37 @@
+---
+layout: plugin
+
+id: dashboard
+layout: plugin
+
+id: dashboard
+title: OctoPrint-Dashboard
+description: A dashboard tab for Octoprint
+author: Stefan Cohen
+license: AGPLv3
+
+# today's date in format YYYY-MM-DD, e.g.
+date: 2019-09-10
+
+homepage: https://github.com/StefanCohen/OctoPrint-Dashboard
+source: https://github.com/StefanCohen/OctoPrint-Dashboard
+archive: https://github.com/StefanCohen/OctoPrint-Dashboard/archive/master.zip
+
+tags:
+- dashboard
+- status
+- overview
+
+screenshots:
+- url: https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot.png
+  alt: screenshot
+  caption: caption of a screenshot
+- url: https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot-theme.png
+  alt: screenshot
+  caption: themed screenshot
+- url: https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot-theme2.png
+
+featuredimage: https://github.com/StefanCohen/OctoPrint-Dashboard/blob/master/screenshot.png
+
+---
+This plugin adds a  dashboard tab in Octoprint that displays the most relevant info regarding the state of the printer and any on-going print jobs.


### PR DESCRIPTION
A dashboard tab for Octoprint that displays the most relevant info regarding the state of the printer and any on-going print jobs.