### PR TITLE
Add new plugin "Creality temperature"

### DIFF
--- a/_plugins/CrealityTemperature.md
+++ b/_plugins/CrealityTemperature.md
@@ -7,7 +7,7 @@ description: Fix to parse correctly temperatures from Creality printer
 author: Romain Odeval, Jean-Christophe Heger
 license: AGPLv3
 
-date: 201-10-26
+date: 2019-10-26
 
 homepage: https://github.com/RomainOdeval/OctoPrint-CrealityTemperature/
 source: https://github.com/RomainOdeval/OctoPrint-CrealityTemperature/

--- a/_plugins/CrealityTemperature.md
+++ b/_plugins/CrealityTemperature.md
@@ -1,0 +1,51 @@
+---
+layout: plugin
+
+id: CrealityTemperature
+title: Creality Temperature Fix
+description: Fix to parse correctly temperatures from Creality printer
+author: Jean-Christophe Heger, Romain Odeval
+license: AGPLv3
+
+date: 201-10-26
+
+homepage: your plugin's homepage
+source: your plugin's source repository
+archive: archive link to install your plugin via pip, e.g. from github: https://github.com/username/repository/archive/master.zip
+
+# Set this to true if your plugin uses the dependency_links setup parameter to include
+# library versions not yet published on pypi. SHOULD ONLY BE USED IF THERE IS NO OTHER OPTION!
+#follow_dependency_links: false
+
+tags:
+- creality
+- temperature
+
+screenshots:
+- url: url of a screenshot, /assets/img/...
+  alt: alt-text of a screenshot
+  caption: caption of a screenshot
+- url: url of another screenshot, /assets/img/...
+  alt: alt-text of another screenshot
+  caption: caption of another screenshot
+- ...
+
+featuredimage: url of a featured image for your plugin, /assets/img/...
+
+compatibility:
+  octoprint:
+  - 1.3.0
+  os:
+  - linux
+  - windows
+  - macos
+  - freebsd
+
+---
+
+Fix to parse correctly temperatures from Creality printers.
+Originally created by Jean-Christophe Heger on https://community.octoprint.org/t/temperature-info-not-parsed-correctly/3557/11
+
+Tested on :
+* CR-10S Pro
+* CR-X

--- a/_plugins/CrealityTemperature.md
+++ b/_plugins/CrealityTemperature.md
@@ -9,8 +9,8 @@ license: AGPLv3
 
 date: 201-10-26
 
-homepage: your plugin's homepage
-source: your plugin's source repository
+homepage: https://github.com/RomainOdeval/OctoPrint-CrealityTemperature/
+source: https://github.com/RomainOdeval/OctoPrint-CrealityTemperature/
 archive: archive link to install your plugin via pip, e.g. from github: https://github.com/username/repository/archive/master.zip
 
 # Set this to true if your plugin uses the dependency_links setup parameter to include

--- a/_plugins/CrealityTemperature.md
+++ b/_plugins/CrealityTemperature.md
@@ -37,7 +37,7 @@ compatibility:
 ---
 
 Fix to parse correctly temperatures from Creality printers.
-Originally created by Jean-Christophe Heger on https://community.octoprint.org/t/temperature-info-not-parsed-correctly/3557/11
+Originally created by Jean-Christophe Heger on https://community.octoprint.org/t/temperature-info-not-parsed-correctly/3557/12
 
 Tested on :
 * CR-10S Pro

--- a/_plugins/CrealityTemperature.md
+++ b/_plugins/CrealityTemperature.md
@@ -4,7 +4,7 @@ layout: plugin
 id: CrealityTemperature
 title: Creality Temperature Fix
 description: Fix to parse correctly temperatures from Creality printer
-author: Jean-Christophe Heger, Romain Odeval
+author: Romain Odeval, Jean-Christophe Heger
 license: AGPLv3
 
 date: 201-10-26

--- a/_plugins/CrealityTemperature.md
+++ b/_plugins/CrealityTemperature.md
@@ -11,7 +11,7 @@ date: 201-10-26
 
 homepage: https://github.com/RomainOdeval/OctoPrint-CrealityTemperature/
 source: https://github.com/RomainOdeval/OctoPrint-CrealityTemperature/
-archive: archive link to install your plugin via pip, e.g. from github: https://github.com/username/repository/archive/master.zip
+archive: https://github.com/RomainOdeval/OctoPrint-CrealityTemperature/releases/latest/download/master.zip
 
 # Set this to true if your plugin uses the dependency_links setup parameter to include
 # library versions not yet published on pypi. SHOULD ONLY BE USED IF THERE IS NO OTHER OPTION!
@@ -22,15 +22,8 @@ tags:
 - temperature
 
 screenshots:
-- url: url of a screenshot, /assets/img/...
-  alt: alt-text of a screenshot
-  caption: caption of a screenshot
-- url: url of another screenshot, /assets/img/...
-  alt: alt-text of another screenshot
-  caption: caption of another screenshot
-- ...
 
-featuredimage: url of a featured image for your plugin, /assets/img/...
+featuredimage: 
 
 compatibility:
   octoprint:

--- a/_plugins/CrealityTemperature.md
+++ b/_plugins/CrealityTemperature.md
@@ -7,7 +7,7 @@ description: Fix to parse correctly temperatures from Creality printer
 author: Romain Odeval, Jean-Christophe Heger
 license: AGPLv3
 
-date: 2019-10-26
+date: 2019-10-28
 
 homepage: https://github.com/RomainOdeval/OctoPrint-CrealityTemperature/
 source: https://github.com/RomainOdeval/OctoPrint-CrealityTemperature/


### PR DESCRIPTION
Add a new plugin, based on Jean-Christophe Heger's work (https://community.octoprint.org/t/temperature-info-not-parsed-correctly/3557/12) to fix temperatures display with Creality printers