### PR TITLE
Add support for python3

### DIFF
--- a/_plugins/PrintTimeGenius.md
+++ b/_plugins/PrintTimeGenius.md
@@ -36,7 +36,7 @@ featuredimage: /assets/img/plugins/PrintTimeGenius/precise.png
 compatibility:
   octoprint:
   - 1.3.9rc1
-
+  python: ">=2.7,<4"
 ---
 
 Generate highly accurate gcode printing time estimations using advanced gcode analyzers combined with the printing history.


### PR DESCRIPTION
Followed [these](https://community.octoprint.org/t/towards-python-3-and-octoprint-1-4-0/12382/1) instructions.  Compatibility changes made [here](https://github.com/eyal0/OctoPrint-PrintTimeGenius/issues/171) and tested by @PlasmaSoftUK.