### PR TITLE
Added date information to plugin details-page

### DIFF
--- a/_layouts/plugin.html
+++ b/_layouts/plugin.html
@@ -68,6 +68,12 @@ layout: default
           {% include adsnippet.html %}
         </dd>
       </dl>
+      {% if page.date %}
+      <dl class="date">
+        <dt>Since</dt>
+        <dd>{{ page.date | strip_html | strip_newlines | escape | date_to_string}}</dd>
+      </dl>
+      {% endif %}
       {% if page.archive %}
       <dl class="installation">
         <dt>Installation <a href="/help/installation/" class="fas fa-question-circle"></a></dt>


### PR DESCRIPTION
Hi,

I missed the date information of each plugin in the detail page. 
Now it looks like this: 
![image](https://user-images.githubusercontent.com/24205767/71168440-01727980-2257-11ea-8238-e719045880fc.png)
