### PR TITLE
Mark DeleteAfterPrint as Python 3 compatible

### DIFF
--- a/_plugins/DeleteAfterPrint.md
+++ b/_plugins/DeleteAfterPrint.md
@@ -30,6 +30,9 @@ screenshots:
   
 featuredimage: https://raw.githubusercontent.com/OllisGit/OctoPrint-DeleteAfterPrint/master/screenshots/sidebar.jpg
 
+compatibility:
+  python: ">=2.7,<4"
+
 ---
 
 Delete/Move automatically the Print-Model: 


### PR DESCRIPTION
See: https://github.com/OllisGit/OctoPrint-DeleteAfterPrint/commit/c25d378149e3802c96243cdeaa5e7acf445e5709