### PR TITLE
Py3 compatibility for firmwareupdater plugin

### DIFF
--- a/_plugins/firmwareupdater.md
+++ b/_plugins/firmwareupdater.md
@@ -23,6 +23,9 @@ tags:
 - due
 - bossac
 
+compatibility:
+  python: ">=2.7,<4"
+
 screenshots:
 - url: /assets/img/plugins/firmwareupdater/firmware-updater.png
   alt: Firmware Updater


### PR DESCRIPTION
Python 3 compatibility merged into plugin in https://github.com/OctoPrint/OctoPrint-FirmwareUpdater/pull/121