### PR TITLE
Printoid plugin supports Python >= 2.7 and < 4

### DIFF
--- a/_plugins/printoid.md
+++ b/_plugins/printoid.md
@@ -20,6 +20,9 @@ tags:
 - Android
 - notifications
 
+compatibility:
+  python: ">=2.7,<4"
+
 screenshots:
 - url: /assets/img/plugins/printoid/notif_progress_10.png
   alt: Notification on print progress


### PR DESCRIPTION
The Printoid plugin is able to run with Python3.7 but marked as "not compatible" when trying to install it on an OctoPrint instance running with Python3.7