### PR TITLE
OctoPrint_Signal-Notifier is py3 compatible

### DIFF
--- a/_plugins/signalnotifier.md
+++ b/_plugins/signalnotifier.md
@@ -29,8 +29,8 @@ featuredimage: /assets/img/plugins/signalnotifier/signalnotifier.png
 
 compatibility:
   # list of compatible versions, for example 1.2.0. If left empty no specific version requirement will be assumed
-  octoprint:
-  - 1.2.0
+  octoprint: 1.2.0   
+  python: ">=2.7,<4" 
 
 ---
 


### PR DESCRIPTION
Confirmed syntax is fine. Tweak metadata entry.