### PR TITLE
Add Author-Link and Release-Infos in Jekyll-Template

### DIFF
--- a/_includes/plugin_author
+++ b/_includes/plugin_author
@@ -1,1 +1,5 @@
+{% if include.nolabel %}
+<a href="{{ '/by_author/' | prepend: site.baseurl }}#{{ include.author | slugify }}">{{ include.author }}</a>
+{% else %}
 <a class="label" href="{{ '/by_author/' | prepend: site.baseurl }}#{{ include.author | slugify }}">{{ include.author }}</a>
+{% endif %}

--- a/_layouts/plugin.html
+++ b/_layouts/plugin.html
@@ -124,6 +124,10 @@ layout: default
         <dt>Github stats</dt>
         <dd>
           <ul>
+            {% if page.github.releases %}
+            <li>Latest Release: <a href="{{ page.github.latest_release_url | strip_html | strip_newlines | escape }}" target="_blank">{{ page.github.latest_release | strip_html | strip_newlines | escape }}</a></li>
+            <li>Releases: {{ page.github.releases }}</li>
+            {% endif %}
             <li>Last update: {{ page.github.last_push | date: "%-d %B %Y" }}</li>
             <li>Stars: {{ page.github.stars }}</li>
             <li>Open Issues: {{ page.github.issues }}</li>

--- a/_layouts/plugin.html
+++ b/_layouts/plugin.html
@@ -174,7 +174,7 @@ layout: default
       {% if page.author %}
       <dl class="author">
         <dt>Author</dt>
-        <dd>{{ page.author | strip_html | strip_newlines | escape }}</dd>
+        <dd>{% include plugin_author author=page.author nolabel='true'%}</dd>
       </dl>
       {% endif %}
       {% if page.homepage %}


### PR DESCRIPTION
In the plugin-view you can now click on the Authors-Name and then you will be delegated to the ```/by_author/#xxx``` page.

Btw. I like the new stats-sections in the view very much. But I have "challenges" to rebuild the site.
After I executed the ```populate_additional_metadata.py``` script (the execution is done without an error, all pages now modified with the new stat-values) I can not start Jekyll.
I received this error:
```
Liquid Exception: undefined method `new' for BigDecimal:Class in /_layouts/plugin.html
jekyll 3.8.5 | Error:  undefined method `new' for BigDecimal:Class
```
Full execution-log is in the following text-file.
[jekyll-execution.log.txt](https://github.com/OctoPrint/plugins.octoprint.org/files/4659066/jekyll-execution.log.txt)

I can't identify which value raise this issue. Do you have a tipp for my, how I can analyse/debug this issue?
