### PR TITLE
Added "closed issue count" to GitHub-Stats

### DIFF
--- a/_layouts/plugin.html
+++ b/_layouts/plugin.html
@@ -124,15 +124,15 @@ layout: default
         <dt>Github stats</dt>
         <dd>
           <ul>
-            {% if page.github.releases %}
+            {% if page.github.releases > 0 %}
             <li>Latest Release: <a href="{{ page.github.latest_release_url | strip_html | strip_newlines | escape }}" target="_blank">{{ page.github.latest_release | strip_html | strip_newlines | escape }}</a></li>
-            <li>Release Date: {{ page.github.latest_release_date | date: "%-d %B %Y"}}</li>
+            <li>Release Date: {{ page.github.latest_release_date | date_to_string}}</li>
             <li>Releases: {{ page.github.releases }}</li>
             {% endif %}
             <li>Stars: {{ page.github.stars }}</li>
             <li>Open Issues: {{ page.github.open_issues }}</li>
             <li>Closed Issues: {{ page.github.closed_issues }}</li>
-            <li>Last update: {{ page.github.last_push | date: "%-d %B %Y" }}</li>
+            <li>Last update: {{ page.github.last_push | date_to_string }}</li>
           </ul>
         </dd>
       </dl>

--- a/_layouts/plugin.html
+++ b/_layouts/plugin.html
@@ -126,11 +126,13 @@ layout: default
           <ul>
             {% if page.github.releases %}
             <li>Latest Release: <a href="{{ page.github.latest_release_url | strip_html | strip_newlines | escape }}" target="_blank">{{ page.github.latest_release | strip_html | strip_newlines | escape }}</a></li>
+            <li>Release Date: {{ page.github.latest_release_date | date: "%-d %B %Y"}}</li>
             <li>Releases: {{ page.github.releases }}</li>
             {% endif %}
-            <li>Last update: {{ page.github.last_push | date: "%-d %B %Y" }}</li>
             <li>Stars: {{ page.github.stars }}</li>
-            <li>Open Issues: {{ page.github.issues }}</li>
+            <li>Open Issues: {{ page.github.open_issues }}</li>
+            <li>Closed Issues: {{ page.github.closed_issues }}</li>
+            <li>Last update: {{ page.github.last_push | date: "%-d %B %Y" }}</li>
           </ul>
         </dd>
       </dl>
@@ -224,4 +226,3 @@ layout: default
 
   </div>
 </div>
-

--- a/_plugins/eeprom_marlin_printrbot.md
+++ b/_plugins/eeprom_marlin_printrbot.md
@@ -9,9 +9,9 @@ license: AGPLv3
 
 date: 2015-12-26
 
-homepage: https://github.com/ryanneufeld/OctoPrint-EEprom-Marlin
-source: https://github.com/ryanneufeld/OctoPrint-EEprom-Marlin
-archive: https://github.com/ryanneufeld/OctoPrint-EEprom-Marlin/archive/master.zip
+homepage: https://github.com/ryanneufeld/OctoPrint-EEPROM-Marlin-Printrbot
+source: https://github.com/ryanneufeld/OctoPrint-EEPROM-Marlin-Printrbot
+archive: https://github.com/ryanneufeld/OctoPrint-EEPROM-Marlin-Printrbot/archive/master.zip
 
 follow_dependency_links: false
 


### PR DESCRIPTION
Based on the feature request from @jneilliii https://github.com/OctoPrint/plugins.octoprint.org/issues/486

I looked into the graphql-api, but also with that approach I can't reduce the API-Calls.
So, I just added a search-call to collect the missing "closed-count" 

Result:
![image](https://user-images.githubusercontent.com/24205767/82732879-72d7bc00-9d10-11ea-941a-b155c4d81019.png)
