### PR TITLE
Added Python 3 compatibility to OctoFlat & Prusa m73 override

### DIFF
--- a/_plugins/OctoFlat.md
+++ b/_plugins/OctoFlat.md
@@ -7,6 +7,9 @@ description: A flat theme for OctoPrint.
 author: Joseph Geis
 license: MIT
 
+compatibility:
+  python: ">=2.7,<4"
+
 # TODO
 date: 2019-06-03
 

--- a/_plugins/actiontrigger.md
+++ b/_plugins/actiontrigger.md
@@ -12,6 +12,8 @@ date: 2015-04-17
 tags:
 - printing
 ---
+compatibility:
+  python: ">=2.7,<4"
 
 > Its gun do some serial trigger handling yo
 

--- a/_plugins/prusaetaoverride.md
+++ b/_plugins/prusaetaoverride.md
@@ -20,6 +20,10 @@ tags:
 - eta
 - estimation
 - m73
+
+compatibility:
+  python: ">=2.7,<4"
+
 ---
 
 ## About


### PR DESCRIPTION
Added Python 3 compatibility to these plugins, Hopefully I did it right!

Linked issues 
https://github.com/kanocz/octopi_eta_override/issues/7
https://github.com/juniorRubyist/OctoPrint-OctoFlat/issues/1

Edit: I have another plugin that is Py3 compatible, can I add it to this?