### PR TITLE
Mark ThermalRunaway as compatible with both Python 2 and 3

### DIFF
--- a/_plugins/ThermalRunaway.md
+++ b/_plugins/ThermalRunaway.md
@@ -86,7 +86,7 @@ compatibility:
   # If your plugin only supports Python 2 (worst case, not recommended for newly developed plugins since Python 2
   # is EOL), leave at ">=2.7,<3"
   
-  python: ">=3,<4"
+  python: ">=2.7,<4"
 
 ---
 


### PR DESCRIPTION
Update the plugin registration for my plugin ThermalRunaway to mark it as compatible with both Python 2 and 3.