### PR TITLE
Make plugins searchable by tags

### DIFF
--- a/search/index.html
+++ b/search/index.html
@@ -13,6 +13,7 @@ title: Search
             fields: [
                 ["title", {boost: 10}],
                 ["description", {boost: 5}],
+                ["tags", {boost: 5}],
                 ["content"]
             ]
         })


### PR DESCRIPTION
Links to my issue about searching by tags, #568 
Allows searching by tags, with a weighting of 5. (Title 10, description 5, content)