### PR TITLE
Add python 3 compatibility markers

### DIFF
--- a/_plugins/gpx.md
+++ b/_plugins/gpx.md
@@ -17,6 +17,7 @@ screenshots:
   url: https://markwal.github.io/octoprint-download/gpx.png
 featuredimage: https://markwal.github.io/octoprint-download/gpx.png
 compatibility:
+  python: ">=2.7,<4"
   os:
   - linux
 ---

--- a/_plugins/polarcloud.md
+++ b/_plugins/polarcloud.md
@@ -33,6 +33,7 @@ screenshots:
 featuredimage: /assets/img/plugins/polarcloud/polarcloud.png
 
 compatibility:
+  python: ">=2.7,<4"
   octoprint:
   - 1.3.4
 

--- a/_plugins/portlister.md
+++ b/_plugins/portlister.md
@@ -20,6 +20,7 @@ tags:
 - automatic
 
 compatibility:
+  python: ">=2.7,<4"
   os:
   - nix
 

--- a/_plugins/screensquish.md
+++ b/_plugins/screensquish.md
@@ -7,6 +7,8 @@ description: Scalable UI that does some old fashioned (v2) bootstrap responsive 
 author: Mark Walker
 license: AGPLv3
 date: 2015-06-17
+compatibility:
+  python: ">=2.7,<4"
 
 homepage: https://github.com/markwal/OctoPrint-ScreenSquish
 source: https://github.com/markwal/OctoPrint-ScreenSquish


### PR DESCRIPTION
I've got some of my plugins working under Python 3