### PR TITLE
Updated PrintTrack for Python3

### DIFF
--- a/_plugins/printtrack.md
+++ b/_plugins/printtrack.md
@@ -86,6 +86,9 @@ compatibility:
   - macos
   - freebsd
 
+  compatibility:
+    python: ">=2.7,<4"
+
 ---
 
 ### OctoPrint-PrintTrack

--- a/_plugins/printtrack.md
+++ b/_plugins/printtrack.md
@@ -86,8 +86,7 @@ compatibility:
   - macos
   - freebsd
 
-  compatibility:
-    python: ">=2.7,<4"
+  python: ">=2.7,<4"
 
 ---
 


### PR DESCRIPTION
Added compatibility flag for Python3 support on the PrintTrack plugin.