### PR TITLE
Adopt Filament Sensor Reloaded

### DIFF
--- a/_data/notices.yaml
+++ b/_data/notices.yaml
@@ -70,3 +70,11 @@
   date: 2020-09-23 15:15:00Z
   text: Version 0.0.4 of this plugin is available, but due to a name change the automatic update needs a bit of extra
     help. Please uninstall the plugin and then just reinstall it from the plugin repository.
+- plugin: filamentreload
+  pluginversions: ["<1.3.0"]
+  versions: ["1.0.0", "1.1.0", "1.1.1", "1.2.0"]
+  date: 2020-09-27 018:00:00Z
+  text: Version 1.3.0 of this plugin is available from a new maintainer, but your version still looks for updates at the
+    repository of the old maintainer. Please re-install the plugin from the repository to update, keeping your
+    settings. The release notes of the version by the new maintainer can be found at the "Read more..." link below.
+  link: https://github.com/ssorgatem/Octoprint-Filament-Reloaded/releases/tag/1.3.0

--- a/_data/update_check_overlays.yaml
+++ b/_data/update_check_overlays.yaml
@@ -18,3 +18,5 @@ klipper:
   user: AliceGrey
 costestimation:
   user: OllisGit
+filamentreload:
+  user: ssorgatem

--- a/_plugins/filament_sensor_reloaded.md
+++ b/_plugins/filament_sensor_reloaded.md
@@ -4,13 +4,13 @@ layout: plugin
 id: filamentreload
 title: Filament Sensor Reloaded
 description: Use a filament sensor to pause printing when filament runs out.
-author: kontakt
+author: kontakt, ssorgatem
 license: AGPLv3
 date: 2017-01-06
 
-homepage: https://github.com/kontakt/Octoprint-Filament-Reloaded
-source: https://github.com/kontakt/Octoprint-Filament-Reloaded
-archive: https://github.com/kontakt/Octoprint-Filament-Reloaded/archive/master.zip
+homepage: https://github.com/ssorgatem/Octoprint-Filament-Reloaded
+source: https://github.com/ssorgatem/Octoprint-Filament-Reloaded
+archive: https://github.com/ssorgatem/Octoprint-Filament-Reloaded/archive/master.zip
 follow_dependency_links: false
 
 tags:
@@ -24,9 +24,6 @@ compatibility:
 
   os:
   - nix
-  
-abandoned: https://github.com/OctoPrint/plugins.octoprint.org/issues/499
- 
 ---
 Pause printing when the 3D printer runs out of filament.
 


### PR DESCRIPTION
The plugin was abandoned ( https://github.com/OctoPrint/plugins.octoprint.org/issues/499 ) , and I've ported it to Python3 and incorporated some fixes and features that were floating around.
