### PR TITLE
Wording change in EEPROM Marlin notice

### DIFF
--- a/_data/notices.yaml
+++ b/_data/notices.yaml
@@ -83,6 +83,6 @@
   versions: ["0.1.0", "1.0.0", "1.0.1", "1.0.2", "1.0.3", "1.0.4", "1.2", "1.2.1", "1.2.2"]
   date: 2020-10-07 12:00:00Z
   text: Version 2.0.0 of this plugin is available from a new maintainer, but your version still looks for updates at the
-    repository of the old maintainer. Please re-install the plugin from the repository to update, keeping your
-    settings. The release notes of the version by the new maintainer can be found at the "Read more..." link below.
+    repository of the old maintainer. Please uninstall the old plugin from the plugin manager, then reinstall from the plugin
+    repository to update it. The release notes of the version by the new maintainer can be found at the "Read more..." link below.
   link: https://github.com/cp2004/OctoPrint-EEPROM-Marlin/releases/tag/2.0.0


### PR DESCRIPTION
Hopefully avoids problems with just reinstalling the plugin, which doesn't delete the old one since I changed `plugin_name` in setup.py.

Linking https://github.com/cp2004/OctoPrint-EEPROM-Marlin/issues/5