### PR TITLE
Update listing for stats plugin to point to new repo

### DIFF
--- a/_plugins/stats.md
+++ b/_plugins/stats.md
@@ -4,14 +4,14 @@ layout: plugin
 id: stats
 title: Printer Statistics
 description: Statistics of your 3D Printer
-author: Anderson Silva
+author: Alex Verrico
 license: AGPLv3
 
 date: 2015-09-13
 
-homepage: https://github.com/amsbr/OctoPrint-Stats
-source: https://github.com/amsbr/OctoPrint-Stats
-archive: https://github.com/amsbr/OctoPrint-Stats/archive/master.zip
+homepage: https://github.com/AlexVerrico/octoprint-stats
+source: https://github.com/AlexVerrico/octoprint-stats
+archive: https://github.com/AlexVerrico/octoprint-stats/archive/master.zip
 
 follow_dependency_links: false
 
@@ -33,10 +33,8 @@ screenshots:
 
 featuredimage: /assets/img/plugins/stats/img1.png
 
-disabled: The plugin has a dependency that only supports Python 3 now, however it isn't yet marked as Python 3 compatible
-    itself, rendering it uninstallable without code modifications. See [this ticket](https://github.com/OctoPrint/plugins.octoprint.org/issues/434).
-
-abandoned: https://github.com/OctoPrint/plugins.octoprint.org/issues/479
+compatibility:
+  python: ">=2.7,<4"
 
 ---
 

--- a/_plugins/stats.md
+++ b/_plugins/stats.md
@@ -4,7 +4,7 @@ layout: plugin
 id: stats
 title: Printer Statistics
 description: Statistics of your 3D Printer
-author: Alex Verrico
+author: Alex Verrico, originally by Anderson Silva
 license: AGPLv3
 
 date: 2015-09-13


### PR DESCRIPTION
As the original Author of this plugin has confirmed that he will no longer maintain it, I have taken over maintenance at a new repository.
This PR updates the listing for the plugin to point to the new repository (https://github.com/AlexVerrico/octoprint-stats).
I have confirmed that the site still builds correctly using jekyll on Debian 10.
Cheers, Alex.