### PR TITLE
Multiple authors for one plugin

### DIFF
--- a/.github/scripts/validate_front_matter.py
+++ b/.github/scripts/validate_front_matter.py
@@ -58,6 +58,7 @@ SCHEMA = Schema({
 	Required("title"): NonEmptyString,
 	Required("description"): NonEmptyString,
 	Required("author"): NonEmptyString,
+	Optional("authors"): list,
 	Required("license"): NonEmptyString,
 
 	Required("date"): datetime.date,

--- a/_layouts/plugin.html
+++ b/_layouts/plugin.html
@@ -178,7 +178,14 @@ layout: default
           </ul>
         </dd>
       </dl>
-      {% if page.author %}
+      {% if page.authors %}
+      <dl class="author">
+        <dt>Authors</dt>
+        {% for author in page.authors %}
+          <dd>{% include plugin_author author=author nolabel='true'%}</dd>
+        {% endfor %}
+      </dl>
+      {% elsif page.author %}
       <dl class="author">
         <dt>Author</dt>
         <dd>{% include plugin_author author=page.author nolabel='true'%}</dd>

--- a/_plugins/dashboard.md
+++ b/_plugins/dashboard.md
@@ -4,6 +4,7 @@ layout: plugin
 id: dashboard
 title: OctoPrint-Dashboard
 description: A dashboard tab for Octoprint
+author: Stefan Cohen, j7126, Willmac16
 authors:
 - Stefan Cohen
 - j7126

--- a/_plugins/dashboard.md
+++ b/_plugins/dashboard.md
@@ -4,7 +4,10 @@ layout: plugin
 id: dashboard
 title: OctoPrint-Dashboard
 description: A dashboard tab for Octoprint
-author: Stefan Cohen, j7126, Willmac16
+authors:
+- Stefan Cohen
+- j7126
+- Willmac16
 license: AGPLv3
 
 date: 2019-09-10

--- a/by_author/index.html
+++ b/by_author/index.html
@@ -5,10 +5,17 @@ title: Plugins by Author
 
 {% assign all_authors = "" | split: "/" %}
 {% for plugin in site.plugins %}
-  {% assign preprocessed = plugin.author %}
-  {% unless preprocessed == "" %}
-    {% assign all_authors = all_authors | push: preprocessed %}
-  {% endunless %}
+  {% if plugin.authors %}
+    {% for author in plugin.authors %}
+      {% unless author == "" %}
+        {% assign all_authors = all_authors | push: author %}
+      {% endunless %}
+    {% endfor %}
+  {% else %}
+    {% unless plugin.author == "" %}
+      {% assign all_authors = all_authors | push: plugin.author %}
+    {% endunless %}
+  {% endif %}
 {% endfor %}
 {% assign all_authors = all_authors | uniq | sort_natural %}
 
@@ -22,8 +29,16 @@ title: Plugins by Author
   <h2 id="{{ author | slugify }}">{{ author }}</h2>
   <ul>
   {% for plugin in site.plugins %}
-    {% if author == plugin.author  %}
-      <li>{% include plugin_snippet plugin=plugin %}</li>
+    {% if plugin.authors %}
+      {% for a in plugin.authors %}
+        {% if author == a  %}
+          <li>{% include plugin_snippet plugin=plugin %}</li>
+        {% endif %}
+      {% endfor %}
+    {% else %}
+      {% if author == plugin.author  %}
+        <li>{% include plugin_snippet plugin=plugin %}</li>
+      {% endif %}
     {% endif %}
   {% endfor %}
   </ul>

--- a/help/registering/index.md
+++ b/help/registering/index.md
@@ -77,7 +77,12 @@ If all is in the green, follow these steps:
     id: your plugin's identifier
     title: your plugin's name
     description: short description of your plugin
+    # If your pluign has one author 
     author: your name
+    # If your pluign has multiple authors
+    #authors:
+    #- first author name
+    #- second autor name
     license: your plugin's license
 
     # today's date in format YYYY-MM-DD, e.g.

--- a/help/registering/index.md
+++ b/help/registering/index.md
@@ -80,6 +80,7 @@ If all is in the green, follow these steps:
     # If your pluign has one author 
     author: your name
     # If your pluign has multiple authors
+    # NOTE: with multiple authors, author is still required in addition to authors
     #authors:
     #- first author name
     #- second autor name


### PR DESCRIPTION
Adds a new authors property that can be used in any plugin .md file. 

This allows multiple authors for one plugin to be linked on the plugin page and displayed separately in the 'by author' section

![image](https://user-images.githubusercontent.com/35882868/97381102-16f30e00-1914-11eb-8984-f968cd5497e6.png)

![image](https://user-images.githubusercontent.com/35882868/97381152-30945580-1914-11eb-9e3f-8f60c7d17c3f.png)

This PR additionally adds this property for the dashboard plugin. 
