### PR TITLE
More Python 3 compatibility

### DIFF
--- a/_plugins/IFTTT.md
+++ b/_plugins/IFTTT.md
@@ -25,6 +25,9 @@ screenshots:
   alt: OctoPrint-IFTTT Settings
   caption: OctoPrint-IFTTT Settings
 
+compatibility:
+  python: ">=2.7,<4"
+  
 ---
 
 *Note: this plugin has not been tested with versions under 1.3.10; they may not work!*

--- a/_plugins/macro.md
+++ b/_plugins/macro.md
@@ -32,7 +32,7 @@ compatibility:
   - windows
   - macos
   - freebsd
-  python: ">=2.7,<3"
+  python: ">=2.7,<4"
 
 ---
 Adds feature to create various gcode macros and display them in sidebar menu

--- a/_plugins/touchtest.md
+++ b/_plugins/touchtest.md
@@ -26,6 +26,9 @@ screenshots:
 - url: /assets/img/plugins/touchtest/example.png
   alt: Screenshot of Touchtest sidebar panel
   caption: Touchtest sidebar panel
+  
+compatibility:
+  python: ">=2.7,<4"
 
 featuredimage: /assets/img/plugins/touchtest/example.png
 ---


### PR DESCRIPTION
More Python 3 compatibility PRs in the last couple days - up to 76% now. Only one technically needed to be done since I think the rest would be automatically picked up, but they're here just in case that fails 🙂 

* OctoPrint Macro - https://github.com/mike1pol/octoprint_macro/pull/14
* OctoPrint TouchTest - https://github.com/Peaches491/OctoPrint-Touchtest/pull/26
* OctoPrint IFTTT - https://github.com/tjjfvi/OctoPrint-IFTTT/pull/35