### PR TITLE
ready to adopt abandoned plugin.

### DIFF
--- a/_data/notices.yaml
+++ b/_data/notices.yaml
@@ -119,3 +119,11 @@
     repository of the old maintainer. Please uninstall the old plugin from the plugin manager, then reinstall from the plugin
     repository to update it. The release notes of the version by the new maintainer can be found at the "Read more..." link below.
   link: https://github.com/gdombiak/OctoPrint-M73ETAOverride/releases/tag/1.0.4
+- plugin: webcamtab
+  pluginversions: ["<0.2.0"]
+  versions: ["0.1.0", "0.1.1", "0.1.2"]
+  date: 2020-12-09 12:00:00Z
+  text: Version 0.2.0 of this plugin is available from a new maintainer, but your version still looks for updates at the
+    repository of the old maintainer. Please uninstall the old plugin from the plugin manager, then reinstall from the plugin
+    repository to update it. The release notes of the version by the new maintainer can be found at the "Read more..." link below.
+  link: https://github.com/gruvin/OctoPrint-WebcamTab/releases/tag/0.2.0

--- a/_data/update_check_overlays.yaml
+++ b/_data/update_check_overlays.yaml
@@ -29,3 +29,5 @@ continuousprint:
   user: Zinc-OS
 m73etaoverride:
   user: gdombiak
+webcamtab:
+  user: gruvin

--- a/_plugins/webcamtab.md
+++ b/_plugins/webcamtab.md
@@ -8,7 +8,7 @@ authors:
 - Bryan J. Rentoul
 - Sven Lohrmann (original)
 license: AGPLv3
-date: 2020-12-08
+date: 2018-01-16
 homepage: https://github.com/gruvin/OctoPrint-WebcamTab
 source: https://github.com/gruvin/OctoPrint-WebcamTab
 archive: https://github.com/gruvin/OctoPrint-WebcamTab/archive/master.zip

--- a/_plugins/webcamtab.md
+++ b/_plugins/webcamtab.md
@@ -15,12 +15,6 @@ archive: https://github.com/gruvin/OctoPrint-WebcamTab/archive/master.zip
 compatibility:
   octoprint:
   - "1.3.5"
-  - "1.3.6"
-  - "1.3.7"
-  - "1.3.8"
-  - "1.3.9"
-  - "1.4"
-  - "1.5"
   python: ">=2.7,<4"
 tags:
 - webcam

--- a/_plugins/webcamtab.md
+++ b/_plugins/webcamtab.md
@@ -14,7 +14,7 @@ source: https://github.com/gruvin/OctoPrint-WebcamTab
 archive: https://github.com/gruvin/OctoPrint-WebcamTab/archive/master.zip
 compatibility:
   octoprint:
-  - "1.3.5"
+  - 1.3.5
   python: ">=2.7,<4"
 tags:
 - webcam

--- a/_plugins/webcamtab.md
+++ b/_plugins/webcamtab.md
@@ -4,7 +4,8 @@ layout: plugin
 id: webcamtab
 title: WebcamTab
 description: Moves the webcam stream from the controls into its own tab
-author: Bryan J. Rentoul (original Sven Lohrmann)
+author: Bryan J. Rentoul
+authors: Sven Lohrmann (original)
 license: AGPLv3
 date: 2020-12-08
 homepage: https://github.com/gruvin/OctoPrint-WebcamTab
@@ -12,13 +13,14 @@ source: https://github.com/gruvin/OctoPrint-WebcamTab
 archive: https://github.com/gruvin/OctoPrint-WebcamTab/archive/master.zip
 compatibility:
   octoprint:
-  - 1.3.5
-  - 1.3.6
-  - 1.3.7
-  - 1.3.8
-  - 1.3.9
-  - 1.4
-  - 1.5
+  - "1.3.5"
+  - "1.3.6"
+  - "1.3.7"
+  - "1.3.8"
+  - "1.3.9"
+  - "1.4"
+  - "1.5"
+  python: ">=2.7,<4"
 tags:
 - webcam
 - ui

--- a/_plugins/webcamtab.md
+++ b/_plugins/webcamtab.md
@@ -4,8 +4,9 @@ layout: plugin
 id: webcamtab
 title: WebcamTab
 description: Moves the webcam stream from the controls into its own tab
-author: Bryan J. Rentoul
-authors: Sven Lohrmann (original)
+authors:
+- Bryan J. Rentoul
+- Sven Lohrmann (original)
 license: AGPLv3
 date: 2020-12-08
 homepage: https://github.com/gruvin/OctoPrint-WebcamTab

--- a/_plugins/webcamtab.md
+++ b/_plugins/webcamtab.md
@@ -4,18 +4,25 @@ layout: plugin
 id: webcamtab
 title: WebcamTab
 description: Moves the webcam stream from the controls into its own tab
-author: Sven Lohrmann
+author: Bryan J. Rentoul (original Sven Lohrmann)
 license: AGPLv3
-date: 2018-01-16
-homepage: https://github.com/malnvenshorn/OctoPrint-WebcamTab
-source: https://github.com/malnvenshorn/OctoPrint-WebcamTab
-archive: https://github.com/malnvenshorn/OctoPrint-WebcamTab/archive/master.zip
+date: 2020-12-08
+homepage: https://github.com/gruvin/OctoPrint-WebcamTab
+source: https://github.com/gruvin/OctoPrint-WebcamTab
+archive: https://github.com/gruvin/OctoPrint-WebcamTab/archive/master.zip
 compatibility:
   octoprint:
   - 1.3.5
+  - 1.3.6
+  - 1.3.7
+  - 1.3.8
+  - 1.3.9
+  - 1.4
+  - 1.5
 tags:
 - webcam
 - ui
 ---
 
 This OctoPrint plugin moves the webcam stream from the controls into its own tab. Keyboard control is still possible.
+Adopted Dec 2020, as original author no longer contactable. Thanks Sven and hope you're doing fine out there!


### PR DESCRIPTION
ID now matches original plugin, so "upgrades" will happen. Thanks.

There are at least two people already using the new version (0.2.0) and it now supports OctoPrint v1.3.5+, including 1.4.x and 1.5.x.
