### PR TITLE
Fix master archive link.

### DIFF
--- a/_plugins/octolapse.md
+++ b/_plugins/octolapse.md
@@ -10,7 +10,7 @@ date: 2018-03-24
 
 homepage: https://formerlurker.github.io/Octolapse/
 source: https://github.com/FormerLurker/Octolapse/
-archive: https://github.com/FormerLurker/Octolapse/archive/v0.4.0.zip
+archive: https://github.com/FormerLurker/Octolapse/archive/master.zip
 
 tags:
 - timelapse


### PR DESCRIPTION
I goofed and used a direct link to a previous release at some point for the archive URL.  I switched this to the master link.  Thank you!