### PR TITLE
Change maintainer of slack (#797)

### DIFF
--- a/_data/notices.yaml
+++ b/_data/notices.yaml
@@ -135,3 +135,11 @@
     repository of the old maintainer. Please uninstall the old plugin from the plugin manager, then reinstall from the plugin
     repository to update it. The release notes of the version by the new maintainer can be found at the "Read more..." link below.
   link: https://github.com/tkoecker/OctoPrint-Mmu2filamentselect/releases/tag/1.0.3
+- plugin: slack
+  pluginversions: ["<0.2.4"]
+  versions: ["0.1", "0.2", "0.2.1", "0.2.2", "0.2.3"]
+  date: 2021-02-27 17:00:00Z
+  text: Version 0.2.4 of this plugin is available from a new maintainer, but your version still looks for updates at the
+    repository of the old maintainer. Please uninstall the old plugin from the plugin manager, then reinstall from the plugin
+    repository to update it. The release notes of the version by the new maintainer can be found at the "Read more..." link below.
+  link: https://github.com/mkevenaar/OctoPrint-Slack/releases/tag/0.2.4

--- a/_data/update_check_overlays.yaml
+++ b/_data/update_check_overlays.yaml
@@ -33,3 +33,5 @@ webcamtab:
   user: gruvin
 mmu2filamentselect:
   user: tkoecker
+slack:
+  user: mkevenaar

--- a/_plugins/slack.md
+++ b/_plugins/slack.md
@@ -14,7 +14,7 @@ date: 2015-10-28
 
 homepage: https://github.com/mkevenaar/OctoPrint-Slack
 source: https://github.com/mkevenaar/OctoPrint-Slack
-archive: https://github.com/mkevenaar/OctoPrint-Slack/archive/master.zip
+archive: https://github.com/mkevenaar/OctoPrint-Slack/releases/latest/download/release.zip
 
 # set this to true if your plugin uses the dependency_links setup parameter to include
 # library versions not yet published on PyPi. SHOULD ONLY BE USED IF THERE IS NO OTHER OPTION!

--- a/_plugins/slack.md
+++ b/_plugins/slack.md
@@ -4,15 +4,17 @@ layout: plugin
 id: slack
 title: Slack
 description: Send message to Slack chat when printing events happen
-author: Richard Joyce
+authors: 
+  - Maurice Kevenaar
+  - Richard Joyce
 license: MIT
 
 # today's date in format YYYY-MM-DD, e.g.
 date: 2015-10-28
 
-homepage: https://github.com/richjoyce/OctoPrint-Slack
-source: https://github.com/richjoyce/OctoPrint-Slack
-archive: https://github.com/richjoyce/OctoPrint-Slack/archive/master.zip
+homepage: https://github.com/mkevenaar/OctoPrint-Slack
+source: https://github.com/mkevenaar/OctoPrint-Slack
+archive: https://github.com/mkevenaar/OctoPrint-Slack/archive/master.zip
 
 # set this to true if your plugin uses the dependency_links setup parameter to include
 # library versions not yet published on PyPi. SHOULD ONLY BE USED IF THERE IS NO OTHER OPTION!
@@ -36,7 +38,9 @@ screenshots:
 
 featuredimage: /assets/img/plugins/slack/slack.png
 
-abandoned: https://github.com/OctoPrint/plugins.octoprint.org/issues/797
+compatibility:
+  python: ">=2.7,<4"
+
 ---
 Send messages to your group's Slack chat when printing events happen! You need to set up an [Incoming Webhook](https://my.slack.com/services/new/incoming-webhook) integration on the Slack side to use this.
 


### PR DESCRIPTION
See #797 
New release can be found here: https://github.com/mkevenaar/OctoPrint-Slack/releases/tag/0.2.4