### PR TITLE
Fix Python 3 compatibility in CustomCSS

### DIFF
--- a/_plugins/customcss.md
+++ b/_plugins/customcss.md
@@ -19,7 +19,7 @@ tags:
 - settings
 
 compatibility:
-  python: ">=2.7,<3"
+  python: ">=2.7,<4"
 
 ---
 Add your CSS by navigating to Settings -> Plugins -> Custom CSS.


### PR DESCRIPTION
This was showing as Python 2 only, despite the string in the plugin always stating Python 2 & 3.

https://github.com/crankeye/OctoPrint-CustomCSS/blob/7a042b11055592b42b59298ad8d579b731081acd/octoprint_customcss/__init__.py#L77