### PR TITLE
🔧 Adapt issue forms to breaking change

### DIFF
--- a/.github/ISSUE_TEMPLATE/abandoned_plugin.yml
+++ b/.github/ISSUE_TEMPLATE/abandoned_plugin.yml
@@ -2,7 +2,6 @@ name: Report an abandoned plugin
 description: Use this to report plugins that have been confirmed as abandoned
 title: '[Abandoned Plugin] <insert name of plugin here>'
 labels: 'abandoned plugin'
-issue_body: false
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,7 +2,6 @@ name: Feature request
 description: Use this to request new features for the plugin repository (NOT ANY PLUGINS!)
 title: '[Feature Request] <insert short summary of request here>'
 labels: 'enhancement'
-issue_body: true
 body:
   - type: markdown
     attributes:
@@ -23,7 +22,6 @@ body:
       description: Please provide a few examples of the kind of problems that would be solved by implementing the feature request.
     validations:
       required: true
-  - type: markdown
+  - type: textarea
     attributes:
-      value: >
-        **Any additional information you want to provide?**
+      label: Any additional information you want to provide?

--- a/.github/ISSUE_TEMPLATE/listing_error.yml
+++ b/.github/ISSUE_TEMPLATE/listing_error.yml
@@ -2,7 +2,6 @@ name: Report a listing error
 description: Use this to report errors in a plugin list (broken images, broken links, incorrect compatibility information, NOT BUGS IN THE PLUGIN)
 title: '[Listing Error] <insert name of plugin here>'
 labels: 'listing error'
-issue_body: true
 body:
   - type: markdown
     attributes:
@@ -40,11 +39,10 @@ body:
         - a typo in the plugin listing
     validations:
       required: true
-  - type: markdown
+  - type: textarea
     attributes:
-      value: >
-        ### What specifically is broken or wrong?
-
+      label: What specifically is broken or wrong?
+      description: >-
         E.g. what link is broken, which image doesn't display properly, which parts of the
         compatibility information are wrong, where is the typo?
 

--- a/.github/ISSUE_TEMPLATE/suspicious_plugin_activity.yml
+++ b/.github/ISSUE_TEMPLATE/suspicious_plugin_activity.yml
@@ -2,7 +2,6 @@ name: Report suspicious plugin activity
 description: Use this to report plugins that are doing something malicious and/or undocumented (e.g. crypto mining, suspicious network connections, unannounced tracking without opt-in, ...)
 title: '[Suspicious Plugin Activity] <insert name of plugin here>'
 labels: 'suspicious plugin activity'
-issue_body: true
 body:
   - type: markdown
     attributes:
@@ -53,9 +52,8 @@ body:
       placeholder: https://...
     validations:
       required: true
-  - type: markdown
+  - type: textarea
     attributes:
-      value: >
-        ### Further information you want to provide
-
+      label: Further information you want to provide
+      description: >-
         If there's any more information you want to provide, please do this here:


### PR DESCRIPTION
`issue_body` is about to be removed from the schema, `textarea` fields are about to get WYSIWYG attached.

Not to be merged before go-live, approx. Thursday April 9th 2021
