### PR TITLE
Update Camera Settings plugin to require OP 1.4.0+

### DIFF
--- a/_plugins/camerasettings.md
+++ b/_plugins/camerasettings.md
@@ -42,7 +42,7 @@ compatibility:
   # OctoPrint versions being supported.
 
   octoprint:
-  - 1.3.7
+  - 1.4.0
 
   # List of compatible operating systems
   #


### PR DESCRIPTION
Per Discord conversation, since this is Py3 only, it should also be OctoPrint 1.4.0+