### PR TITLE
Add psucontrol_subplugin tag to psucontrol_rpigpio, psucontrol_tasmot…

### DIFF
--- a/_plugins/psucontrol.md
+++ b/_plugins/psucontrol.md
@@ -30,4 +30,4 @@ compatibility:
 
 See <https://github.com/kantlivelong/OctoPrint-PSUControl> for information on configuration.
 
-Sub Plugins: <https://plugins.octoprint.org/by_tag/#tag-psucontrol>
+Sub Plugins: <https://plugins.octoprint.org/by_tag/#tag-psucontrol_subplugin>

--- a/_plugins/psucontrol_rpigpio.md
+++ b/_plugins/psucontrol_rpigpio.md
@@ -14,6 +14,7 @@ tags:
 - psu
 - control
 - psucontrol
+- psucontrol_subplugin
 - gpio
 compatibility:
   os:

--- a/_plugins/psucontrol_tasmota.md
+++ b/_plugins/psucontrol_tasmota.md
@@ -14,6 +14,7 @@ tags:
 - psu
 - control
 - psucontrol
+- psucontrol_subplugin
 - tasmota
 compatibility:
   os:

--- a/_plugins/psucontrol_tendabeli.md
+++ b/_plugins/psucontrol_tendabeli.md
@@ -14,6 +14,7 @@ tags:
 - psu
 - control
 - psucontrol
+- psucontrol_subplugin
 - tenda
 compatibility:
   os:

--- a/_plugins/psucontrol_tplink.md
+++ b/_plugins/psucontrol_tplink.md
@@ -14,6 +14,7 @@ tags:
 - psu
 - control
 - psucontrol
+- psucontrol_subplugin
 - tplink
 compatibility:
   os:

--- a/_plugins/psucontrol_wemo.md
+++ b/_plugins/psucontrol_wemo.md
@@ -14,6 +14,7 @@ tags:
 - psu
 - control
 - psucontrol
+- psucontrol_subplugin
 - wemo
 compatibility:
   os:


### PR DESCRIPTION
Adding `psucontrol_subplugin` tag to all PSUControl sub-plugins for better filtering. Originally was going to just use `psucontrol` for the main plugin and sub-plugins but then `MQTT For PSUControl` was released on the forums which is technically not a sub-plugin. I intend to link to this tag from the main repo and within the plugin.

Given that I do not own `psucontrol_tendabeli` or `psucontrol_wemo` I am not sure if authorization is required from those devs for this particular circumstance.