### PR TITLE
Change 'psucontrol_subplugin' tag to 'psucontrol subplugin'

### DIFF
--- a/_plugins/psucontrol.md
+++ b/_plugins/psucontrol.md
@@ -30,4 +30,4 @@ compatibility:
 
 See <https://github.com/kantlivelong/OctoPrint-PSUControl> for information on configuration.
 
-Sub Plugins: <https://plugins.octoprint.org/by_tag/#tag-psucontrol_subplugin>
+Sub Plugins: <https://plugins.octoprint.org/by_tag/#tag-psucontrol-subplugin>

--- a/_plugins/psucontrol_rpigpio.md
+++ b/_plugins/psucontrol_rpigpio.md
@@ -14,7 +14,7 @@ tags:
 - psu
 - control
 - psucontrol
-- psucontrol_subplugin
+- psucontrol subplugin
 - gpio
 compatibility:
   os:

--- a/_plugins/psucontrol_tasmota.md
+++ b/_plugins/psucontrol_tasmota.md
@@ -14,7 +14,7 @@ tags:
 - psu
 - control
 - psucontrol
-- psucontrol_subplugin
+- psucontrol subplugin
 - tasmota
 compatibility:
   os:

--- a/_plugins/psucontrol_tendabeli.md
+++ b/_plugins/psucontrol_tendabeli.md
@@ -14,7 +14,7 @@ tags:
 - psu
 - control
 - psucontrol
-- psucontrol_subplugin
+- psucontrol subplugin
 - tenda
 compatibility:
   os:

--- a/_plugins/psucontrol_tplink.md
+++ b/_plugins/psucontrol_tplink.md
@@ -14,7 +14,7 @@ tags:
 - psu
 - control
 - psucontrol
-- psucontrol_subplugin
+- psucontrol subplugin
 - tplink
 compatibility:
   os:

--- a/_plugins/psucontrol_wemo.md
+++ b/_plugins/psucontrol_wemo.md
@@ -14,7 +14,7 @@ tags:
 - psu
 - control
 - psucontrol
-- psucontrol_subplugin
+- psucontrol subplugin
 - wemo
 compatibility:
   os:


### PR DESCRIPTION
Forgot that underscores would be converted to hyphens in the URL. While fixing I decided to just use a space instead.
