### PR TITLE
Rename plugin Draggable Files

### DIFF
--- a/_plugins/draggable_files.md
+++ b/_plugins/draggable_files.md
@@ -2,7 +2,7 @@
 layout: plugin
 
 id: draggable_files
-title: OctoPrint-Draggable_files
+title: Draggable Files
 description: Plugin that allows for the dragging of files in the File Manager
 authors:
   - Sander Ronde


### PR DESCRIPTION
Change the Draggable Files plugin title to match the target title, as suggested in https://github.com/OctoPrint/plugins.octoprint.org/pull/887#issuecomment-858840819.