### PR TITLE
Fix image url in matrix notifier

### DIFF
--- a/_plugins/matrix_notifier.md
+++ b/_plugins/matrix_notifier.md
@@ -21,11 +21,11 @@ tags:
 - shapshots
 
 screenshots:
-- url: /assets/img/plugins/printstarted.png
+- url: /assets/img/plugins/matrix_notifier/printstarted.png
   alt: A print started message
   caption: A matrix notification showing a print started message and a snapshot image.
 
-featuredimage: /assets/img/plugins/printstarted.png
+featuredimage: /assets/img/plugins/matrix_notifier/printstarted.png
 
 compatibility:
   # Compatible Python version

--- a/_plugins/matrix_notifier.md
+++ b/_plugins/matrix_notifier.md
@@ -47,7 +47,7 @@ The message templates support markdown which are converted to HTML to send as fo
 
 In addition to this any other event should be configurable directly in the `config.yaml` file.
 
-Take the event name from https://docs.octoprint.org/en/master/events/ and add a section under the `plugins:` section which looks like this:
+Take the event name from [the OctoPrint events documentation](https://docs.octoprint.org/en/master/events/) and add a section under the `plugins:` section which looks like this:
 
 ```
   matrix_notifier:


### PR DESCRIPTION
I got the URL wrong and didn't notice till I saw the update in the octoprint UI :frowning_face: 