### PR TITLE
 🧟 PrintHistory plugin has been resurrected. Adding back

### DIFF
--- a/_plugins/printhistory.md
+++ b/_plugins/printhistory.md
@@ -1,0 +1,16 @@
+---
+layout: plugin
+id: printhistory
+title: Print History
+description: Saves filename, print time and filament usage for each print
+archive: https://github.com/imrahil/OctoPrint-PrintHistory/archive/master.zip
+homepage: https://github.com/imrahil/OctoPrint-PrintHistory
+source: https://github.com/imrahil/OctoPrint-PrintHistory
+author: Guy Sheffer
+license: AGPLv3
+featuredimage: https://github.com/imrahil/OctoPrint-PrintHistory/raw/master/printhistory.png?raw=true
+date: 2020-07-27
+
+---
+
+![PrintHistory](https://github.com/imrahil/OctoPrint-PrintHistory/raw/master/printhistory.png?raw=true)


### PR DESCRIPTION
New 1.3 version adds python3 support and handles folder payload correctly.