### PR TITLE
Fix update URL for maintainer change

### DIFF
--- a/_data/update_check_overlays.yaml
+++ b/_data/update_check_overlays.yaml
@@ -41,3 +41,4 @@ HeaterTimeout:
   user: Andy-ch
 smartfilamentsensor:
   user: Royrdan
+  pip: https://github.com/Royrdan/Octoprint-Smart-Filament-Sensor/archive/{target_version}.zip


### PR DESCRIPTION
Overrides the pip url for downloading the update.

Bit of an experiment to be honest, but should work. This has come up a couple of times before but with the standard notice saying to 'reinstall the plugin' to get the new maintainer's version I guess it goes away on it's own.

Following up from https://github.com/OctoPrint/plugins.octoprint.org/issues/983#issuecomment-1026283233

I won't merge it straight away - it's late here so it would be good for someone else to double check the logic.

@Royrdan this will probably override it for your repo as well - if you ever need to change the pip URL, then let us know here and we'll sort it.