### PR TITLE
Add psucontrol_tapo plugin description

### DIFF
--- a/_plugins/psucontrol_tapo.md
+++ b/_plugins/psucontrol_tapo.md
@@ -8,7 +8,7 @@ homepage: https://github.com/dswd/OctoPrint-PSUControl-Tapo
 source: https://github.com/dswd/OctoPrint-PSUControl-Tapo
 author: Dennis Schwerdel
 license: AGPLv3
-date: 2022-04-10
+date: 2022-04-14
 tags:
 - power
 - psu

--- a/_plugins/psucontrol_tapo.md
+++ b/_plugins/psucontrol_tapo.md
@@ -1,0 +1,26 @@
+---
+layout: plugin
+id: psucontrol_tapo
+title: PSU Control - Tapo
+description: Adds Tapo Smart Plug support to OctoPrint-PSUControl as a sub-plugin 
+archive: https://github.com/dswd/OctoPrint-PSUControl-Tapo/archive/master.zip
+homepage: https://github.com/dswd/OctoPrint-PSUControl-Tapo
+source: https://github.com/dswd/OctoPrint-PSUControl-Tapo
+author: Dennis Schwerdel
+license: AGPLv3
+date: 2022-04-10
+tags:
+- power
+- psu
+- control
+- psucontrol
+- psucontrol subplugin
+- tapo
+compatibility:
+  os:
+  - posix
+  - windows
+  python: ">=2.7,<4"
+---
+
+See <https://github.com/dswd/OctoPrint-PSUControl-Tapo> for information on configuration.


### PR DESCRIPTION
This PR adds a subplugin psucontrol_tapo for the TPLink Tapo devices. The code and the description is adapted from psucontrol_tplink. (Thanks to the author!)