### PR TITLE
OctoPrint-BedCooldown: Change requirement to Python 3

### DIFF
--- a/_plugins/bedcooldown.md
+++ b/_plugins/bedcooldown.md
@@ -32,7 +32,7 @@ screenshots:
 featuredimage: /assets/img/plugins/bedcooldown/graph.png
 
 compatibility:
-  python: ">=2.7,<4"
+  python: ">=3,<4"
 
 ---
 


### PR DESCRIPTION
Ref: https://github.com/rfinnie/OctoPrint-BedCooldown/commit/2008052f71e384c263a1215d5ddaf692e50152cd