### PR TITLE
node 12 deprecation

### DIFF
--- a/.github/workflows/publish-to-github-pages.yml
+++ b/.github/workflows/publish-to-github-pages.yml
@@ -16,17 +16,17 @@ jobs:
     name: Publish to Github Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: src
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: live
           ref: master
 
       - name: 🐍 Set up Python 3.7
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.7"
 


### PR DESCRIPTION
Update publish-to-github-pages.yml for action/checkout@v3 for deprecated node 12.