### PR TITLE
Adopting plugin SlicerSettingsParser

### DIFF
--- a/_data/notices.yaml
+++ b/_data/notices.yaml
@@ -204,3 +204,11 @@
     repository of the old maintainer. Please uninstall the old plugin from the plugin manager, then reinstall from the plugin
     repository to update it. The release notes of the version by the new maintainer can be found at the "Read more..." link below.
   link: https://github.com/gbonesso/OctoPrint-LEDStripControl/releases/tag/v0.3.8
+- plugin: SlicerSettingsParser
+  pluginversions: ["<3.0.0"]
+  versions: []
+  date: 2022-12-11 18:00:00Z
+  text: Version 3.0.0 of this plugin is available from a new maintainer, but your version still looks for updates at the
+    repository of the old maintainer. Please uninstall the old plugin from the plugin manager, then reinstall from the plugin
+    repository to update it. The release notes of the version by the new maintainer can be found at the "Read more..." link below.
+  link: https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser/releases/tag/3.0.0

--- a/_data/update_check_overlays.yaml
+++ b/_data/update_check_overlays.yaml
@@ -46,3 +46,5 @@ ledstripcontrol:
   user: gbonesso
 excluderegion:
   user: bradcfisher
+SlicerSettingsParser:
+  user: larsjuhw

--- a/_plugins/SlicerSettingsParser.md
+++ b/_plugins/SlicerSettingsParser.md
@@ -2,34 +2,66 @@
 layout: plugin
 
 id: SlicerSettingsParser
-title: OctoPrint-SlicerSettingsParser
+title: SlicerSettingsParser
 description: Plugin to analyze gcode for slicer settings comments and add additional metadata of such settings.
-author: T6
+authors:
+- Larsjuhw
+- T6
 license: AGPLv3
 
 date: 2018-12-22
 
-homepage: https://github.com/tjjfvi/OctoPrint-SlicerSettingsParser
-source: https://github.com/tjjfvi/OctoPrint-SlicerSettingsParser
-archive: https://github.com/tjjfvi/OctoPrint-SlicerSettingsParser/archive/master.zip
+homepage: https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser
+source: https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser
+archive: https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser/archive/master.zip
 
 tags:
 - gcode
 - analysis
 - slicer settings
 
-abandoned: https://github.com/OctoPrint/plugins.octoprint.org/issues/1058
+compatibility:
+  python: ">=3,<4"
+
 ---
 
-**NOTE: Only supports Slic3r and Simplify3D currently; suggest more in issues; contributions welcome!**
-
-*Note: this plugin has not been tested with versions under 1.3.10; they may not work!*
+# SlicerSettingsParser
 
 *This plugin is useless without another plugin to use the metadata. Those can be found [here](/by_tag/#tag-slicer-settings).*
 
-## Configuration
+### Compatible plugins
+Check out [ExtraFileInfo](/plugins/ExtraFileInfo) for an example of what this plugin can do.
 
-### Python regexes (Advanced)
+### Configuration
+#### Scan limit
+
+Scanning all files entirely can take a considerable amount of time when your gcode library is large. A Raspberry Pi 4B seems to parse at a rate of about 4 MB/s. Every file you upload will be scanned, and choosing a scan limit in the settings will drastically reduce the scan time.
+
+#### Cura
+
+Cura doesn't natively support injecting the slicer settings into the gcode, so you must add [this](https://gist.github.com/tjjfvi/75210b2ed20ed194d6eab48bf70c4f12) to your start/end gcode. Preferably add it to the start gcode, so that you can configure this plugin to stop parsing when it sees the first extrusion command. [Here](http://files.fieldofview.com/cura/Replacement_Patterns.html) are all the available gcode variables that Cura supports.
+
+#### Python regexes
+##### Cura
+
+If you use the start/end gcode provided above, use this regex:
+```regex
+^;\s*(?P<key>\w+[\w\s]*) : (?P<val>.*)
+```
+
+##### Slic3r
+
+```regex
+^; (?P<key>[^,]*?) = (?P<val>.*)
+```
+
+##### Simplify3D
+
+```regex
+^;   (?P<key>.*?),(?P<val>.*)
+```
+
+##### Other
 
 This plugin uses python regexes to parse the gcode.
 Syntax can be easily found on the web.
@@ -37,4 +69,4 @@ There should be two named capturing groups, `key` and `val`.
 Multiple regexes should be listed on seperate lines, ordered by precedence.
 Any chars are allowed in the groups; `\n` will be replaced by newlines.
 
-See the [wiki](https://github.com/tjjfvi/OctoPrint-SlicerSettingsParser/wiki/Python-regexes) for examples.
+If you can not figure it out yourself, open an issue and I can take a look.


### PR DESCRIPTION
Adopting SlicerSettingsParser to solve https://github.com/OctoPrint/plugins.octoprint.org/issues/1058. Updated to v3.0.0 to add Python 3 compatibility and other changes at https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser. 

Need someone to check if I did everything properly.