### PR TITLE
Adopt SlicerSettingsTab and change SlicerSettingsParser requirements

### DIFF
--- a/_plugins/SlicerSettingsParser.md
+++ b/_plugins/SlicerSettingsParser.md
@@ -21,7 +21,7 @@ tags:
 - slicer settings
 
 compatibility:
-  python: ">=3,<4"
+  python: ">=2.7,<4"
 
 ---
 

--- a/_plugins/SlicerSettingsTab.md
+++ b/_plugins/SlicerSettingsTab.md
@@ -4,14 +4,16 @@ layout: plugin
 id: SlicerSettingsTab
 title: OctoPrint-SlicerSettingsTab
 description: Adds tab which displays slicer settings of selected gcode file.
-author: T6
+authors:
+- Larsjuhw
+- T6
 license: AGPLv3
 
 date: 2018-12-22
 
-homepage: https://github.com/tjjfvi/OctoPrint-SlicerSettingsTab
-source: https://github.com/tjjfvi/OctoPrint-SlicerSettingsTab
-archive: https://github.com/tjjfvi/OctoPrint-SlicerSettingsTab/archive/master.zip
+homepage: https://github.com/larsjuhw/OctoPrint-SlicerSettingsTab
+source: https://github.com/larsjuhw/OctoPrint-SlicerSettingsTab
+archive: https://github.com/larsjuhw/OctoPrint-SlicerSettingsTab/archive/master.zip
 
 tags:
 - gcode
@@ -43,3 +45,5 @@ compatibility:
 
 This plugin requires also installing [SlicerSettingsParser](/plugins/SlicerSettingsParser)
 or another plugin that adds a metadata dict under `slicer_settings`.
+
+You can pin a setting to the top by clicking on the setting text.


### PR DESCRIPTION
Changes SlicerSettingsTab's author and URLs to adopt the plugin and resolve https://github.com/OctoPrint/plugins.octoprint.org/issues/1137. Already released an update which adds support for Python 3 and some other changes.

Also changes SlicerSettingsParser's Python compatibility to include Python 2 again, as testing showed that it still works. Hope it's not a problem that these changes are combined.