### PR TITLE
Fixed broken link in `SlicerSettingsParser` notice

### DIFF
--- a/_data/notices.yaml
+++ b/_data/notices.yaml
@@ -211,4 +211,4 @@
   text: Version 3.0.0 of this plugin is available from a new maintainer, but your version still looks for updates at the
     repository of the old maintainer. Please uninstall the old plugin from the plugin manager, then reinstall from the plugin
     repository to update it. The release notes of the version by the new maintainer can be found at the "Read more..." link below.
-  link: https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser/releases/tag/3.0.0
+  link: https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser/releases/tag/v3.0.0

--- a/_data/notices.yaml
+++ b/_data/notices.yaml
@@ -211,4 +211,4 @@
   text: Version 3.0.0 of this plugin is available from a new maintainer, but your version still looks for updates at the
     repository of the old maintainer. Please uninstall the old plugin from the plugin manager, then reinstall from the plugin
     repository to update it. The release notes of the version by the new maintainer can be found at the "Read more..." link below.
-  link: https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser/releases/tag/v3.0.0
+  link: https://github.com/larsjuhw/OctoPrint-SlicerSettingsParser/releases/tag/v3.0.1


### PR DESCRIPTION
The notice for `SlicerSettingsParser` contains a broken link; Fixed it.
Following #1136.
@larsjuhw - FYI :)