### PR TITLE
Add plugin Connect And Print

### DIFF
--- a/_plugins/connectandprint.md
+++ b/_plugins/connectandprint.md
@@ -19,3 +19,8 @@ tags:
 - connect
 - upload
 - file
+
+compatibility:
+  python: ">=2.7,<4"
+
+---

--- a/_plugins/connectandprint.md
+++ b/_plugins/connectandprint.md
@@ -13,7 +13,7 @@ date: 2023-04-26
 
 homepage: https://github.com/Maxinger15/connectandprint
 source: https://github.com/Maxinger15/connectandprint
-archive: https://github.com/Maxinger15/connectandprint/archive/master.zip
+archive: https://raw.githubusercontent.com/Maxinger15/connectandprint/master/connect_and_print.py
 
 tags:
 - connect

--- a/_plugins/connectandprint.md
+++ b/_plugins/connectandprint.md
@@ -24,3 +24,18 @@ compatibility:
   python: ">=2.7,<4"
 
 ---
+
+With the Connect and Print plugin, you can save time and effort, as there's no need to manually connect to the printer and start the print job after uploading a file. 
+Just upload your G-code file and let the plugin handle the rest.
+
+#### Features
+
+- Automatically connects to the printer if not already connected upon file upload.
+- Starts printing the uploaded file immediately after a successful connection.
+- Implements a 2-minute timeout for printer connection attempts.
+- Works with OctoPrint's REST API to streamline the printing process.
+
+#### Note: 
+Please ensure that your printer is properly configured and connected to OctoPrint before using this plugin. 
+In case of a failed connection attempt, the plugin will log an error message after the 2-minute timeout.
+

--- a/_plugins/connectandprint.md
+++ b/_plugins/connectandprint.md
@@ -1,0 +1,21 @@
+---
+layout: plugin
+
+id: connectandprint
+title: Connect And Print
+description: Automatically connect to your printer and start the print job on file upload
+authors:
+- Max Grallinger
+
+license: AGPLv3
+
+date: 2023-04-26
+
+homepage: https://github.com/Maxinger15/connectandprint
+source: https://github.com/Maxinger15/connectandprint
+archive: https://github.com/Maxinger15/connectandprint/archive/master.zip
+
+tags:
+- connect
+- upload
+- file

--- a/_plugins/connectandprint.md
+++ b/_plugins/connectandprint.md
@@ -13,7 +13,7 @@ date: 2023-04-26
 
 homepage: https://github.com/Maxinger15/connectandprint
 source: https://github.com/Maxinger15/connectandprint
-archive: https://raw.githubusercontent.com/Maxinger15/connectandprint/master/connect_and_print.py
+archive: https://raw.githubusercontent.com/Maxinger15/connectandprint/master/connectandprint.py
 
 tags:
 - connect


### PR DESCRIPTION
This plugin connects octoprint automaticlly to your printer if you upload a file.
This is useful if you turn of your printer put octoprint is powered on constantly.