### PR TITLE
OctoRelay: update Python version support

### DIFF
--- a/_plugins/octorelay.md
+++ b/_plugins/octorelay.md
@@ -85,7 +85,7 @@ compatibility:
   # If your plugin only supports Python 2 (worst case, not recommended for newly developed plugins since Python 2
   # is EOL), leave at ">=2.7,<3"
 
-  python: ">=2.7,<4"
+  python: ">=3.7,<4"
 
 ---
 


### PR DESCRIPTION
I'm a new maintainer of OctoRelay plugin.

Minimum Python version for the plugin was changed from 2.7 to 3.7 in since the plugin version 2.0.0.

Proof:

https://github.com/borisbu/OctoRelay/blob/2f3996b6ba212c5ba30d42f3eb5a9af41ab33a25/octoprint_octorelay/__init__.py#L304