### PR TITLE
OctoRelay: updating compatibility

### DIFF
--- a/_plugins/octorelay.md
+++ b/_plugins/octorelay.md
@@ -54,7 +54,7 @@ compatibility:
   # OctoPrint versions being supported.
 
   octoprint:
-  - 1.3.0
+  - 1.5.3
 
   # List of compatible operating systems
   #


### PR DESCRIPTION
Changing the minimum compatible OctoPrint version to the latest patch of v1.5.
Based on the recent findings running unit- and integration tests.