### PR TITLE
Update automaticshutdown.md

### DIFF
--- a/_plugins/automaticshutdown.md
+++ b/_plugins/automaticshutdown.md
@@ -32,8 +32,6 @@ compatibility:
   - 1.2.5
   python: ">=2.7,<4"
 
-abandoned: https://github.com/OctoPrint/plugins.octoprint.org/issues/646
-
 ---
 
 This OctoPrint plugin enables the system to be automatically shut down after a print is finished.


### PR DESCRIPTION
removed "abandoned"-flag, since plugin got updated 2023-01-18 see: https://github.com/OctoPrint/OctoPrint-AutomaticShutdown/releases, "abandoned" was originally introduced with: https://github.com/OctoPrint/plugins.octoprint.org/issues/646