### PR TITLE
adopt PrintJobHistory plugin

### DIFF
--- a/_data/notices.yaml
+++ b/_data/notices.yaml
@@ -240,7 +240,6 @@
   pluginversions: ["<1.17.1"]
   versions: []
   date: 2023-11-27 12:00:00Z
-  text: Version 1.17.1 of this plugin is available from a new maintainer, but your version still looks for updates at the
-    repository of the old maintainer. Please re-install the plugin from the repository to update and keep your
-    settings. The release notes of the version by the new maintainer can be found at the "Read more..." link below.
+  text: Version 1.17.1 of this plugin is available from a new maintainer. The release notes of the version by the
+    new maintainer can be found at the "Read more..." link below.
   link: https://github.com/dojohnso/OctoPrint-PrintJobHistory/releases/tag/1.17.1

--- a/_data/notices.yaml
+++ b/_data/notices.yaml
@@ -236,3 +236,11 @@
     repository of the old maintainer. Please re-install the plugin from the repository to update and keeping your
     settings. The release notes of the version by the new maintainer can be found at the "Read more..." link below.
   link: https://github.com/thomst08/OctoLight/releases/tag/v0.1.5
+- plugin: PrintJobHistory
+  pluginversions: ["<1.17.1"]
+  versions: []
+  date: 2023-11-27 12:00:00Z
+  text: Version 1.17.1 of this plugin is available from a new maintainer, but your version still looks for updates at the
+    repository of the old maintainer. Please re-install the plugin from the repository to update and keep your
+    settings. The release notes of the version by the new maintainer can be found at the "Read more..." link below.
+  link: https://github.com/dojohnso/OctoPrint-PrintJobHistory/releases/tag/1.17.1

--- a/_data/update_check_overlays.yaml
+++ b/_data/update_check_overlays.yaml
@@ -56,4 +56,4 @@ octolight:
   user: thomst08
 PrintJobHistory:
   user: dojohnso
-  pip: https://github.com/dojohnso/OctoPrint-PrintJobHistory/archive/{target_version}.zip
+  pip: https://github.com/dojohnso/OctoPrint-PrintJobHistory/releases/download/{target_version}/main.zip

--- a/_data/update_check_overlays.yaml
+++ b/_data/update_check_overlays.yaml
@@ -54,3 +54,5 @@ webhooks:
   pip: https://github.com/derekantrican/OctoPrint-Webhooks/archive/{target_version}.zip
 octolight:
   user: thomst08
+PrintJobHistory:
+  user: dojohnso

--- a/_data/update_check_overlays.yaml
+++ b/_data/update_check_overlays.yaml
@@ -56,3 +56,4 @@ octolight:
   user: thomst08
 PrintJobHistory:
   user: dojohnso
+  pip: https://github.com/dojohnso/OctoPrint-PrintJobHistory/archive/{target_version}.zip

--- a/_plugins/PrintJobHistory.md
+++ b/_plugins/PrintJobHistory.md
@@ -9,7 +9,7 @@ authors:
     - Olli
 license: AGPLv3
 
-date: 2023-11-27
+date: 2020-05-28
 
 homepage: https://github.com/dojohnso/OctoPrint-PrintJobHistory
 source: https://github.com/dojohnso/OctoPrint-PrintJobHistory

--- a/_plugins/PrintJobHistory.md
+++ b/_plugins/PrintJobHistory.md
@@ -3,15 +3,17 @@ layout: plugin
 
 id: PrintJobHistory
 title: PrintJobHistory
-description: The OctoPrint-Plugin stores all print-job informations of a print in a database.
-author: Olli
+description: The OctoPrint-Plugin stores all print-job information of a print in a database.
+authors:
+    - dojohnso
+    - Olli
 license: AGPLv3
 
-date: 2020-05-28
+date: 2023-11-27
 
-homepage: https://github.com/OllisGit/OctoPrint-PrintJobHistory
-source: https://github.com/OllisGit/OctoPrint-PrintJobHistory
-archive: https://github.com/OllisGit/OctoPrint-PrintJobHistory/releases/latest/download/master.zip
+homepage: https://github.com/dojohnso/OctoPrint-PrintJobHistory
+source: https://github.com/dojohnso/OctoPrint-PrintJobHistory
+archive: https://github.com/dojohnso/OctoPrint-PrintJobHistory/releases/latest/download/main.zip
 
 follow_dependency_links: false
 
@@ -58,14 +60,13 @@ abandoned: https://github.com/OctoPrint/plugins.octoprint.org/issues/1222
 
 ---
 
-Print Job History-Plugin collects a lot of attributes from OctoPrint itself, like **Filename, Start/End-Time, Status, Username, Slicer-Settings** and many more. But it also grabs informations from other plugins: **Thumbnail, Layer-Information, Filament usage**...
+Print Job History-Plugin collects a lot of attributes from OctoPrint itself, like **Filename, Start/End-Time, Status, Username, Slicer-Settings** and many more. But it also grabs information from other plugins: **Thumbnail, Layer-Information, Filament usage**...
 
 For a full overview of the latest feature set and planed features, please visit the [Git Hub Homepage]({{ page.homepage | absolute_url }})
 
 
-#### Support my Efforts
+## *NOTE: this plugin has been abandoned by the original creator and adopted here by a new maintainer*
 
-This plugin, as well as my [other plugins](https://github.com/OllisGit/) were developed in my spare time.
-If you like it, I would be thankful about a cup of coffee :)
+**This plugin is under new management** and will focus on critical bug fixes to start. Please bear with me as I get acclimated to this new plugin. If you would like to support these new efforts, please consider buying me a coffee or two. Thank you!
 
-[![paypal](/assets/img/plugins/SpoolManager/paypal-with-text.png)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=6SW5R6ZUKLB5E&source=url)
+<a href="https://www.buymeacoffee.com/djohnson.tech" target="_blank"><img src="https://djohnson.tech/images/white-button.png" width=300 /></a>


### PR DESCRIPTION
Updated references to point to my fork of the repo for v1.17.1 (previously 1.17.0). The release includes a couple bug fixes people were waiting for, otherwise it's the same. 

https://github.com/dojohnso/OctoPrint-PrintJobHistory/releases/tag/1.17.1

Let me know if I missed anything or need to do anything else. Thank you!