### PR TITLE
Added plugin ActivatePrusaHostTimer

### DIFF
--- a/_plugins/ActivatePrusaHostTimer.md
+++ b/_plugins/ActivatePrusaHostTimer.md
@@ -1,0 +1,51 @@
+---
+layout: plugin
+
+id: ActivatePrusaHostTimer
+title: Activate Prusa HostTimer
+description: Plugin for Octoprint to activate Prusa host features
+author: sarusani
+license: AGPLv3
+
+date: 2023-12-01
+
+homepage: https://github.com/sarusani/OctoPrint-ActivatePrusaHostTimer
+source: https://github.com/sarusani/OctoPrint-ActivatePrusaHostTimer
+archive: https://github.com/sarusani/OctoPrint-ActivatePrusaHostTimer/archive/master.zip
+
+follow_dependency_links: false
+
+tags:
+- prusa
+
+compatibility:
+  # List of compatible versions
+  octoprint:
+  - 1.3.0
+
+  # List of compatible operating systems
+  os:
+  - linux
+  - windows
+  - macos
+  - freebsd
+
+  # Compatible Python version
+  python: ">=3.7,<4"
+---
+
+# Activate Prusa HostTimer
+
+Plugin for Octoprint to activate Prusa host features.
+
+Features:
+- Sends M79 S"OP" to printer every x seconds
+- Interval is configurable (5,10,15,20 or 25 seconds)
+- Interval can be paused
+
+## Setup
+
+Install via the bundled [Plugin Manager](https://github.com/foosel/OctoPrint/wiki/Plugin:-Plugin-Manager)
+or manually using this URL:
+
+    https://github.com/sarusani/OctoPrint-ActivatePrusaHostTimer/archive/master.zip


### PR DESCRIPTION
This plugin "pings" the printer every x seconds with a "M79 S"OP"". (The interval can be configured in the settings page, default is 20 seconds)

This ping is needed to activate the print host capabilities of Prusa printers and is expected at least every 30 seconds.
See https://github.com/prusa3d/Prusa-Firmware/pull/4520 for more information.