### PR TITLE
Add Wake-on-LAN plugin

### DIFF
--- a/_plugins/_plugins/wake_on_lan.md
+++ b/_plugins/_plugins/wake_on_lan.md
@@ -1,0 +1,22 @@
+layout: plugin
+
+id: wakeonlan
+title: Wake-on-LAN
+description: An OctoPrint plugin to send Wake-on-LAN packets.
+authors:
+  - Aridor Joskowich
+  - Itay Zelikovich
+license: AGPLv3
+
+date: 2024-07-06
+
+homepage: https://github.com/Aridor2003/OctoPrint-Wakeonlan
+source: https://github.com/Aridor2003/OctoPrint-Wakeonlan
+archive: https://github.com/Aridor2003/OctoPrint-Wakeonlan/archive/master.zip
+
+tags:
+  - network
+  - utility
+
+compatibility:
+  python: ">=3,<4"

--- a/_plugins/_plugins/wake_on_lan.md
+++ b/_plugins/_plugins/wake_on_lan.md
@@ -12,7 +12,7 @@ date: 2024-07-06
 
 homepage: https://github.com/Aridor2003/OctoPrint-Wakeonlan
 source: https://github.com/Aridor2003/OctoPrint-Wakeonlan
-archive: https://github.com/Aridor2003/OctoPrint-Wakeonlan/archive/master.zip
+archive: https://github.com/Aridor2003/OctoPrint-Wakeonlan/archive/main.zip
 
 tags:
   - network


### PR DESCRIPTION
Description:
This pull request adds the Wake-on-LAN plugin to the OctoPrint Plugin Repository. The plugin allows users to send Wake-on-LAN packets to wake up networked devices. Here are the details:
- Repository: https://github.com/Aridor2003/OctoPrint-Wakeonlan
- Author: Aridor Joskowich
- Email: aridor.j@gmail.com
- Compatibility: OctoPrint >= 1.3.0, Python >= 3.6
- License: AGPLv3
- Tags: network, utility
