### PR TITLE
update OctoLapse python compatibility

### DIFF
--- a/_plugins/octolapse.md
+++ b/_plugins/octolapse.md
@@ -27,7 +27,7 @@ compatibility:
   - windows
   - macos
   - freebsd
-  python: ">=2.7,<4"
+  python: ">=2.7,<3.12"
 
 ---
 


### PR DESCRIPTION
update OctoLapse python compatibility to restrict less than python 3.12 due to use of deprecated distutils. @FormerLurker if/when you get that refactored to be compatible we can switch it back. 