### PR TITLE
Release Camera Streamer Prusa Connect Uploader

### DIFF
--- a/_plugins/prusa_connect_uploader.md
+++ b/_plugins/prusa_connect_uploader.md
@@ -1,0 +1,50 @@
+---
+layout: plugin
+
+id: prusa_connect_uploader
+title: Prusa Connect Uploader
+description: Uploads webcam snapshots from OctoPrint to Prusa Connect for enhanced remote monitoring.
+authors:
+- Rizz
+license: MIT
+
+date: 2025-05-01
+
+homepage: https://github.com/rizz360/prusa_connect_uploader
+source: https://github.com/rizz360/prusa_connect_uploader
+archive: https://github.com/rizz360/prusa_connect_uploader/archive/refs/tags/1.0.3.zip
+
+tags:
+- prusa
+- monitoring
+- camera
+- snapshot
+- remote access
+
+#screenshots:
+#- url: /assets/img/plugins/prusa_connect_uploader/docs/config-panel.png
+#  alt: "Plugin settings view"
+#  caption: "Configure your token and upload interval from the settings tab."
+
+#featuredimage: /assets/img/plugins/prusa_connect_uploader/example.png
+
+compatibility:
+  octoprint:
+  - 1.10.3
+
+  os:
+  - linux
+  - windows
+  - macos
+
+  python: ">=3,<4"
+
+attributes:
+  - cloud
+---
+
+Prusa Connect Uploader is an OctoPrint plugin that captures webcam snapshots and uploads them to [Prusa Connect](https://connect.prusa3d.com) for remote viewing and monitoring.
+
+Easily configure your upload token and snapshot frequency from the plugin settings. Once set up, snapshots will be pushed automatically during printing, improving your visibility while away from the printer.
+
+See the [README](https://github.com/rizz360/prusa_connect_uploader#readme) for detailed setup instructions.

--- a/_plugins/prusa_connect_uploader.md
+++ b/_plugins/prusa_connect_uploader.md
@@ -12,7 +12,7 @@ date: 2025-05-01
 
 homepage: https://github.com/rizz360/prusa_connect_uploader
 source: https://github.com/rizz360/prusa_connect_uploader
-archive: https://github.com/rizz360/prusa_connect_uploader/archive/refs/tags/1.0.3.zip
+archive: https://github.com/rizz360/prusa_connect_uploader/archive/refs/heads/main.zip
 
 tags:
 - prusa


### PR DESCRIPTION
Hi! This is my first OctoPrint plugin submission.

Prusa Connect Uploader is a simple plugin that captures webcam snapshots from OctoPrint and uploads them to [Prusa Connect](https://connect.prusa3d.com/), making it easier to monitor ongoing prints remotely through Prusa’s interface.

It allows users to:
- Set their Prusa Connect token
- Configure upload intervals
- Automatically upload snapshots to Prusa Connect

I've followed the plugin metadata format and included the required fields (including archive, python, cloud attribute, etc.). I hope I did everything correctly — feedback is more than welcome!

Thanks to the OctoPrint community for making plugin development so accessible 🙌