### PR TITLE
Add OctoPrint-PlotlyGraph-LYWSD03MMC plugin entry (#1)

### DIFF
--- a/_plugins/lywsd03mmc-plugin-for-plotly-temp-graph.md
+++ b/_plugins/lywsd03mmc-plugin-for-plotly-temp-graph.md
@@ -1,17 +1,17 @@
 ---
 layout: plugin
 
-id: plotly_graph_lywsd03mmc
-title: OctoPrint-PlotlyGraph-LYWSD03MMC
-description: Plugin to add LYWSD03MMC temperature and humidity sensor data to PlotlyTempGraph
+id: OctoPrint-LYWSD03MMC-Plugin-for-PlotlyTempGraph
+title: OctoPrint-LYWSD03MMC-Plugin-for-PlotlyTempGraph
+description: OctoPrint plugin that adds LYWSD03MMC temperature and humidity sensor data to PlotlyTempGraph
 author: yutaka551
 license: MIT
 
-date: 2026-02-22
+date: 2026-03-07
 
-homepage: https://github.com/yutaka551/lywsd03mmc-plotly-graph
-source: https://github.com/yutaka551/lywsd03mmc-plotly-graph
-archive: https://github.com/yutaka551/lywsd03mmc-plotly-graph/archive/master.zip
+homepage: https://github.com/yutaka551/lywsd03mmc-plugin-for-plotly-temp-graph
+source: https://github.com/yutaka551/lywsd03mmc-plugin-for-plotly-temp-graph
+archive: https://github.com/yutaka551/lywsd03mmc-plugin-for-plotly-temp-graph/archive/master.zip
 
 follow_dependency_links: false
 

--- a/_plugins/plotly_graph_lywsd03mmc.md
+++ b/_plugins/plotly_graph_lywsd03mmc.md
@@ -1,0 +1,52 @@
+---
+layout: plugin
+
+id: plotly_graph_lywsd03mmc
+title: OctoPrint-PlotlyGraph-LYWSD03MMC
+description: Plugin to add LYWSD03MMC temperature and humidity sensor data to PlotlyTempGraph
+author: yutaka551
+license: MIT
+
+date: 2026-02-22
+
+homepage: https://github.com/yutaka551/lywsd03mmc-plotly-graph
+source: https://github.com/yutaka551/lywsd03mmc-plotly-graph
+archive: https://github.com/yutaka551/lywsd03mmc-plotly-graph/archive/master.zip
+
+follow_dependency_links: false
+
+tags:
+- temperature
+- humidity
+- bluetooth
+- sensor
+- plotly
+
+compatibility:
+  octoprint:
+  - 1.3.6
+  python: ">=3,<4"
+
+---
+
+# OctoPrint-PlotlyGraph-LYWSD03MMC
+
+OctoPrint plugin to add [LYWSD03MMC](https://www.aliexpress.com/item/4000351449649.html) (Xiaomi Mijia) Bluetooth temperature and humidity sensor data to [PlotlyTempGraph](https://github.com/jneilliii/OctoPrint-PlotlyTempGraph).
+
+## Requirements
+
+- [PlotlyTempGraph plugin](https://github.com/jneilliii/OctoPrint-PlotlyTempGraph)
+- LYWSD03MMC Bluetooth temperature and humidity sensor
+- Bluetooth support on your OctoPrint host (e.g., Raspberry Pi with built-in Bluetooth)
+
+## Features
+
+- Read temperature and humidity from LYWSD03MMC Bluetooth sensors
+- Display sensor data in OctoPrint's temperature graph
+- Configurable update interval
+- Optional display of humidity and battery level
+- Customizable graph labels
+
+## Get Help
+
+If you experience issues with this plugin or need assistance please use the issue tracker at the plugin's Homepage linked on the right.


### PR DESCRIPTION
* Add LYWSD03MMC Plugin for PlotlyTempGraph entry

- [x] You have read the ["Registering a new Plugin"](https://plugins.octoprint.org/help/registering/) guide.
- [x] You want to and are able to maintain the plugin you are registering, long-term.
- [x] You understand why the plugin you are registering works.
- [x] You have read and acknowledge the [Code of Conduct](https://octoprint.org/conduct/).


#### What is the name of your plugin?

LYWSD03MMC Plugin for PlotlyTempGraph

#### What does your plugin do?

This plugin integrates Xiaomi LYWSD03MMC Bluetooth temperature and humidity sensors with OctoPrint, providing real-time environmental data visualization using Plotly graphs. It allows users to monitor temperature and humidity near their 3D printer directly from the OctoPrint interface.

#### Where can we find the source code of your plugin?

https://github.com/yutaka551/lywsd03mmc-plugin-for-plotly-temp-graph

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this plugin?

Yes, GitHub Copilot  were used to assist with code generation and documentation.

#### Is your plugin commercial in nature?

No, this plugin is open-source and not commercial.

#### Does your plugin rely on some cloud services?

No, the plugin operates locally and does not depend on any cloud services.

#### Further notes

None
