### PR TITLE
Add InfillCode plugin

### DIFF
--- a/_plugins/infillcode.md
+++ b/_plugins/infillcode.md
@@ -1,0 +1,34 @@
+---
+layout: plugin
+
+id: infillcode
+title: InfillCode
+description: Embeds per-layer fingerprints into 3D print infill line spacing. When a print fails, a webcam snapshot identifies the last good layer and generates a resume GCode file automatically. Includes startup bed scanning, mid-print health monitoring, and one-click resume.
+author: Dr Steve Mander
+license: MIT
+date: 2026-04-13
+
+homepage: https://github.com/st7ma784/infillcoder
+source: https://github.com/st7ma784/infillcoder
+archive: https://github.com/st7ma784/infillcoder/releases/download/v0.2.0/infillcode-0.2.0.tar.gz
+
+tags:
+- gcode
+- resume
+- recovery
+- failure recovery
+- fingerprint
+- webcam
+- automation
+- filament runout
+
+compatibility:
+  octoprint:
+  - 1.4.0
+  os:
+  - linux
+  - windows
+  - macos
+  - freebsd
+  python: ">=3.7"
+---

--- a/_plugins/infillcode.md
+++ b/_plugins/infillcode.md
@@ -38,6 +38,6 @@ The Plugin embeds per-layer fingerprints into 3D print infill line spacing. When
 
 If you like it, I would be thankful about a cup of coffee :)
 
-[![paypal](/assets/img/plugins/bedlevelvisualizer/paypal-with-text.png)](https://www.paypal.com/donate/?business=FM3XGWAZJNGXU&no_recurring=0&currency_code=GBP)
+[![paypal](/assets/img/plugins/infillcoder/paypal-donate.svg)](https://www.paypal.com/donate/?business=FM3XGWAZJNGXU&no_recurring=0&currency_code=GBP)
 
 For implementation details please visit the [homepage]({{ page.homepage | absolute_url }}).

--- a/_plugins/infillcode.md
+++ b/_plugins/infillcode.md
@@ -10,7 +10,7 @@ date: 2026-04-13
 
 homepage: https://github.com/st7ma784/infillcoder
 source: https://github.com/st7ma784/infillcoder
-archive: https://github.com/st7ma784/infillcoder/releases
+archive: https://github.com/st7ma784/infillcoder/archive/refs/heads/main.zip
 tags:
 - gcode
 - resume

--- a/_plugins/infillcode.md
+++ b/_plugins/infillcode.md
@@ -10,8 +10,7 @@ date: 2026-04-13
 
 homepage: https://github.com/st7ma784/infillcoder
 source: https://github.com/st7ma784/infillcoder
-archive: https://github.com/st7ma784/infillcoder/releases/download/v0.2.0/infillcode-0.2.0.tar.gz
-
+archive: https://github.com/st7ma784/infillcoder/releases
 tags:
 - gcode
 - resume
@@ -31,4 +30,14 @@ compatibility:
   - macos
   - freebsd
   python: ">=3.7"
----
+
+
+The Plugin embeds per-layer fingerprints into 3D print infill line spacing. When a print fails, a webcam snapshot identifies the last good layer and generates a resume GCode file automatically. Includes startup bed scanning, mid-print health monitoring, and one-click resume.
+
+#### Support my Efforts
+
+If you like it, I would be thankful about a cup of coffee :)
+
+[![More coffee, more code](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/donate/?business=FM3XGWAZJNGXU&no_recurring=0&currency_code=GBP)
+
+For implementation details please visit the [homepage]({{ page.homepage | absolute_url }}).

--- a/_plugins/infillcode.md
+++ b/_plugins/infillcode.md
@@ -30,7 +30,7 @@ compatibility:
   - macos
   - freebsd
   python: ">=3.7"
-
+---
 
 The Plugin embeds per-layer fingerprints into 3D print infill line spacing. When a print fails, a webcam snapshot identifies the last good layer and generates a resume GCode file automatically. Includes startup bed scanning, mid-print health monitoring, and one-click resume.
 
@@ -38,6 +38,6 @@ The Plugin embeds per-layer fingerprints into 3D print infill line spacing. When
 
 If you like it, I would be thankful about a cup of coffee :)
 
-[![More coffee, more code](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/donate/?business=FM3XGWAZJNGXU&no_recurring=0&currency_code=GBP)
+[![paypal](/assets/img/plugins/bedlevelvisualizer/paypal-with-text.png)](https://www.paypal.com/donate/?business=FM3XGWAZJNGXU&no_recurring=0&currency_code=GBP)
 
 For implementation details please visit the [homepage]({{ page.homepage | absolute_url }}).

--- a/assets/img/plugins/infillcode/paypal-donate.svg
+++ b/assets/img/plugins/infillcode/paypal-donate.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 200 40" width="200" height="40">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" style="stop-color:#003087;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#002154;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="200" height="40" rx="4" fill="url(#grad)"/>
+  <text x="100" y="24" font-family="Arial, sans-serif" font-size="14" font-weight="bold" fill="white" text-anchor="middle">Donate with PayPal</text>
+</svg>


### PR DESCRIPTION
- [x] You have read the ["Registering a new Plugin"](https://plugins.octoprint.org/help/registering/) guide.
- [x] You want to and are able to maintain the plugin you are registering, long-term.
- [x] You understand why the plugin you are registering works.
- [x] You have read and acknowledge the [Code of Conduct](https://octoprint.org/conduct/).

#### What is the name of your plugin?
InfillCode
#### What does your plugin do?
Having filament run out can be a pain and waste perfectly good prints and filament. This plugin edits the spacing of linear infill layers so that a camera can detect where the print got to, and create gcode to resume from where the print stopped! 

#### Where can we find the source code of your plugin?

https://github.com/st7ma784/infillcoder

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this plugin?

Yes - Claude has helped with some of the logic

#### Is your plugin commercial in nature?

No, 

#### Does your plugin rely on some cloud services?
No

#### Further notes

InfillCode embeds a per-layer fingerprint into 3D print infill line spacing. When a print fails, a webcam snapshot identifies the last completed layer and generates a resume GCode file automatically. I quite like using Arc-welder (shout out!!) so this is set to auto-process .aw.gcode uploads, startup bed scan, mid-print health monitoring with rolling score, optional auto-pause, one-click resume button.
