### PR TITLE
Revert "bedcooldown: Migrate from github.com to codeberg.org"

### DIFF
--- a/_plugins/bedcooldown.md
+++ b/_plugins/bedcooldown.md
@@ -10,9 +10,9 @@ license: MPL-2.0
 
 date: 2021-09-26
 
-homepage: https://codeberg.org/rfinnie/OctoPrint-BedCooldown
-source: https://codeberg.org/rfinnie/OctoPrint-BedCooldown
-archive: https://codeberg.org/rfinnie/OctoPrint-BedCooldown/archive/release.zip
+homepage: https://github.com/rfinnie/OctoPrint-BedCooldown
+source: https://github.com/rfinnie/OctoPrint-BedCooldown
+archive: https://github.com/rfinnie/OctoPrint-BedCooldown/archive/release.zip
 
 follow_dependency_links: false
 


### PR DESCRIPTION
Reverts OctoPrint/plugins.octoprint.org#1430