### PR TITLE
Adopt Octoslack plugin

### DIFF
--- a/_data/notices.yaml
+++ b/_data/notices.yaml
@@ -396,3 +396,12 @@
     Version 1.2.0 of this plugin is available from a new maintainer. The release notes of the version by the
     new maintainer can be found at the "Read more..." link below.
   link: https://github.com/triodes/OctoPrint-PSUControl-Shelly/releases/tag/1.2.0
+- plugin: Octoslack
+  pluginversions: ["<2.2.1"]
+  versions: []
+  date: 2026-05-06 12:00:00Z
+  text:
+    Version 2.2.1 of this plugin is available from a new maintainer. The release notes of the version by the
+    new maintainer can be found at the "Read more..." link below.
+  link: https://github.com/misconfigurations/Octoslack/releases/tag/2.2.1
+

--- a/_data/update_check_overlays.yaml
+++ b/_data/update_check_overlays.yaml
@@ -80,3 +80,6 @@ sidebarmacros:
 psucontrol_shelly:
   user: triodes
   pip: https://github.com/triodes/OctoPrint-PSUControl-Shelly/archive/{target_version}.zip
+octoslack:
+  user: misconfigurations
+  pip: https://github.com/misconfigurations/Octoslack/archive/{target_version}.zip

--- a/_plugins/Octoslack.md
+++ b/_plugins/Octoslack.md
@@ -4,7 +4,7 @@ layout: plugin
 id: Octoslack
 title: Octoslack
 description: An OctoPrint plugin for monitoring your printer and prints via Slack, Mattermost, Pushbullet, Pushover, Rocket.Chat, Discord, Riot/Matrix, or Microsoft Teams
-author: Šárka Hawke
+author: Chris Fraschetti
 license: MIT
 
 # today's date in format YYYY-MM-DD, e.g.

--- a/_plugins/Octoslack.md
+++ b/_plugins/Octoslack.md
@@ -4,15 +4,15 @@ layout: plugin
 id: Octoslack
 title: Octoslack
 description: An OctoPrint plugin for monitoring your printer and prints via Slack, Mattermost, Pushbullet, Pushover, Rocket.Chat, Discord, Riot/Matrix, or Microsoft Teams
-author: Chris Fraschetti
+author: Šárka Hawke
 license: MIT
 
 # today's date in format YYYY-MM-DD, e.g.
-date: 2017-05-20
+date: 2026-05-06
 
-homepage: https://github.com/fraschetti/Octoslack
-source: https://github.com/fraschetti/Octoslack
-archive: https://github.com/fraschetti/Octoslack/archive/master.zip
+homepage: https://github.com/misconfigurations/Octoslack
+source: https://github.com/misconfigurations/Octoslack
+archive: https://github.com/misconfigurations/Octoslack/archive/master.zip
 
 # Set this to true if your plugin uses the dependency_links setup parameter to include
 # library versions not yet published on pypi. SHOULD ONLY BE USED IF THERE IS NO OTHER OPTION!
@@ -50,7 +50,7 @@ tags:
 - gcode
 
 compatibility:
-  python: ">=2.7,<4"
+  python: ">=3.7,<4"
 
 screenshots:
 - url: /assets/img/plugins/Octoslack/Octoslack-PrintStarted.png
@@ -82,8 +82,6 @@ featuredimage: /assets/img/plugins/Octoslack/Octoslack-PrintProgress_SlackOnly.p
 
 attributes:
 - cloud
-
-abandoned: https://github.com/OctoPrint/plugins.octoprint.org/issues/1432
 ---
 
 

--- a/_plugins/Octoslack.md
+++ b/_plugins/Octoslack.md
@@ -4,7 +4,9 @@ layout: plugin
 id: Octoslack
 title: Octoslack
 description: An OctoPrint plugin for monitoring your printer and prints via Slack, Mattermost, Pushbullet, Pushover, Rocket.Chat, Discord, Riot/Matrix, or Microsoft Teams
-author: Chris Fraschetti
+authors:
+    - Šárka Hawke
+    - Chris Fraschetti
 license: MIT
 
 # today's date in format YYYY-MM-DD, e.g.

--- a/_plugins/Octoslack.md
+++ b/_plugins/Octoslack.md
@@ -8,7 +8,7 @@ author: Šárka Hawke
 license: MIT
 
 # today's date in format YYYY-MM-DD, e.g.
-date: 2026-05-06
+date: 2017-05-20
 
 homepage: https://github.com/misconfigurations/Octoslack
 source: https://github.com/misconfigurations/Octoslack


### PR DESCRIPTION
Adopting Octoslack plugin after abandonment #1432 

I used #1420 PR as an example on how to make adoption PR. I even made same mistake with changing the date in OctoSlack.md file which I reverted back to original. 