### PR TITLE
bedcooldown: Migrate from github.com to forge.colobox.com (Forgejo)

### DIFF
--- a/_plugins/bedcooldown.md
+++ b/_plugins/bedcooldown.md
@@ -10,9 +10,9 @@ license: MPL-2.0
 
 date: 2021-09-26
 
-homepage: https://github.com/rfinnie/OctoPrint-BedCooldown
-source: https://github.com/rfinnie/OctoPrint-BedCooldown
-archive: https://github.com/rfinnie/OctoPrint-BedCooldown/archive/release.zip
+homepage: https://forge.colobox.com/rfinnie/OctoPrint-BedCooldown
+source: https://forge.colobox.com/rfinnie/OctoPrint-BedCooldown
+archive: https://forge.colobox.com/rfinnie/OctoPrint-BedCooldown/archive/release.zip
 
 follow_dependency_links: false
 


### PR DESCRIPTION
This follows an aborted attempt (OctoPrint/plugins.octoprint.org#1430 original + OctoPrint/plugins.octoprint.org#1431 revert) to migrate from github.com to codeberg.org. The upstream Codeberg issue has been resolved so OctoPrint plugins can live at at Codeberg, but in the meantime I've migrated to self-hosted Forgejo at Colobox Forge (forge.colobox.com).

Plugin release 0.8.3 includes an in-plugin Forgejo updater, plus support for upcoming Octoprint 2.0.0 which includes native Forgejo support.

Thanks to @jneilliii for finding and reverting the Codeberg issue.