### PR TITLE
Add Layer Notify plugin

### DIFF
--- a/_plugins/layer_notify.md
+++ b/_plugins/layer_notify.md
@@ -1,0 +1,56 @@
+---
+layout: plugin
+
+id: layer_notify
+title: Layer Notify
+description: Receive visual and sound alerts when specific layers are reached during printing, with optional GCODE commands per layer (e.g. M600 for filament change).
+authors:
+- Benaa42
+license: AGPLv3
+
+date: 2026-06-01
+
+homepage: https://github.com/Benaa42/octoprint-layer-notify
+source: https://github.com/Benaa42/octoprint-layer-notify
+archive: https://github.com/Benaa42/octoprint-layer-notify/archive/main.zip
+
+follow_dependency_links: false
+
+tags:
+- notification
+- layer
+- gcode
+- alert
+- sound
+- filament change
+- M600
+
+screenshots:
+- url: https://raw.githubusercontent.com/Benaa42/octoprint-layer-notify/main/docs/screenshot_settings.png
+  alt: Settings panel showing layer list and sound configuration
+  caption: Configure target layers with optional GCODE commands and sound alerts
+- url: https://raw.githubusercontent.com/Benaa42/octoprint-layer-notify/main/docs/screenshot_tab.png
+  alt: Layer Notify tab with real-time status
+  caption: Dedicated tab showing which layers have fired and which are waiting
+
+featuredimage: https://raw.githubusercontent.com/Benaa42/octoprint-layer-notify/main/docs/screenshot_tab.png
+
+compatibility:
+  python: ">=3,<4"
+  octoprint:
+  - 1.4.0
+
+---
+
+Layer Notify lets you set one or more target layers and receive an alert — visual (browser toast + OS notification) and audible (configurable sound) — the moment that layer starts printing.
+
+Each entry can also trigger a GCODE command automatically, making it easy to pause for a filament change (`M600`), show a message on the printer display (`M117 Check print`), or run any other command at a specific point in the print.
+
+**Features:**
+
+- Multiple target layers, each with its own optional GCODE command
+- 4 built-in sound types (single beep, triple beep, alternating alarm, rising tone)
+- Adjustable volume and repeat count (1–10 times)
+- Real-time status tab: see which layers have fired and which are still waiting
+- Works with Cura, PrusaSlicer, SuperSlicer — and any slicer via Z-movement detection
+- Each layer fires only once per print job

--- a/_plugins/layer_notify.md
+++ b/_plugins/layer_notify.md
@@ -40,6 +40,8 @@ compatibility:
   octoprint:
   - 1.4.0
 
+attributes:
+- ai-developed
 ---
 
 Layer Notify lets you set one or more target layers and receive an alert — visual (browser toast + OS notification) and audible (configurable sound) — the moment that layer starts printing.

--- a/_plugins/layer_notify.md
+++ b/_plugins/layer_notify.md
@@ -40,8 +40,6 @@ compatibility:
   octoprint:
   - 1.4.0
 
-attributes:
-- ai-developed
 ---
 
 Layer Notify lets you set one or more target layers and receive an alert — visual (browser toast + OS notification) and audible (configurable sound) — the moment that layer starts printing.


### PR DESCRIPTION
- [x] You have read the ["Registering a new Plugin"](https://plugins.octoprint.org/help/registering/) guide.
- [x] You want to and are able to maintain the plugin you are registering, long-term.
- [x] You understand why the plugin you are registering works.
- [x] You have read and acknowledge the [Code of Conduct](https://octoprint.org/conduct/).

#### What is the name of your plugin?

Layer Notify

#### What does your plugin do?

Sends a visual notification (browser toast + OS native notification) and an optional sound alert when a specific layer is reached during a print job. Each target layer can also trigger a GCODE command automatically (e.g. `M600` for a filament change, `M117` to show a message on the printer display). Multiple target layers can be configured independently, each with its own command, sound and enable toggle.

#### Where can we find the source code of your plugin?

https://github.com/Benaa42/octoprint-layer-notify

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this plugin?

Yes — Claude (Anthropic) was used as a coding assistant during development. All code was reviewed and tested on a physical printer (Creality Ender S1 PRO) before submission.

#### Is your plugin commercial in nature?

No, it is free and open-source (AGPLv3).

#### Does your plugin rely on some cloud services?

No. All functionality runs locally inside OctoPrint. No external services or internet connection required.

#### Further notes

- Layer detection works via slicer GCODE comments (Cura `;LAYER:X`, PrusaSlicer `; layer X,`) with a Z-movement fallback that works with any slicer.
- Sound alerts are generated in the browser via the Web Audio API — no audio files needed.
- Tested on OctoPrint 1.11.7 / Python 3.11 / Raspberry Pi (OctoPi).