### PR TITLE
Add Alexa OctoPrint

### DIFF
--- a/_plugins/alexaoctoprint.md
+++ b/_plugins/alexaoctoprint.md
@@ -1,0 +1,41 @@
+---
+layout: plugin
+
+id: alexaoctoprint
+title: Alexa OctoPrint
+description: Control selected OctoPrint and 3D printer actions through Alexa over the local network without a cloud backend.
+authors:
+- RICLAMER
+license: Proprietary
+
+date: 2026-07-16
+
+homepage: https://github.com/RICLAMER/AlexaOctoPrint
+source: https://github.com/RICLAMER/AlexaOctoPrint
+archive: https://raw.githubusercontent.com/RICLAMER/AlexaOctoPrint/main/plugin/OctoPrint-AlexaOctoPrint.zip
+
+tags:
+- alexa
+- automation
+- control
+- raspberrypi
+
+compatibility:
+  octoprint:
+  - ">=1.6.0"
+  os:
+  - linux
+  python: ">=3.7,<4"
+
+attributes:
+- ai-developed
+
+---
+
+Alexa OctoPrint exposes enabled printer actions as local Philips Hue compatible devices. Discovery and control stay on the LAN; no external backend, Alexa skill, account, or cloud relay is required by the plugin.
+
+The plugin supports print control, homing and leveling, configurable Z and extrusion moves, bed and hotend temperatures, motor shutdown, guarded cancellation, configured print files, and optional OctoPrint-Enclosure outputs for printer power and lighting.
+
+**Additional setup is required on OctoPi.** Alexa local Hue discovery expects HTTP port 80 and root Hue paths. OctoPi's existing HAProxy remains the only listener on port 80 and must selectively forward `/description.xml`, `POST /api`, and Hue light paths to the plugin on OctoPrint's internal port 5000. The project README provides a tested configuration snippet and safety instructions. The plugin does not modify system services automatically.
+
+The Software Update hook reads the latest version from the public distribution repository and installs the matching package through OctoPrint's bundled Software Update plugin.


### PR DESCRIPTION
- [x] You have read the ["Registering a new Plugin"](https://plugins.octoprint.org/help/registering/) guide.
- [x] You want to and are able to maintain the plugin you are registering, long-term.
- [x] You understand why the plugin you are registering works.
- [x] You have read and acknowledge the [Code of Conduct](https://octoprint.org/conduct/).

#### What is the name of your plugin?

Alexa OctoPrint

#### What does your plugin do?

It exposes selected OctoPrint and 3D printer actions as Philips Hue compatible devices that Alexa can discover and control directly over the local network. Supported actions include print control, motion, heating presets, emergency shutdown, configured files, and optional OctoPrint-Enclosure power/light outputs.

#### Where can we find the source code of your plugin?

https://github.com/RICLAMER/AlexaOctoPrint

The repository contains the public documentation and current source distribution package under plugin/.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this plugin?

Yes. OpenAI Codex assisted with implementation, tests, debugging, and English documentation. The maintainer defined the requirements and performed iterative testing against a physical Raspberry Pi, OctoPrint installation, Alexa devices, printer, and Enclosure outputs. The registration metadata includes the required ai-developed attribute.

#### Is your plugin commercial in nature?

No.

#### Does your plugin rely on some cloud services?

No cloud backend or Alexa skill is used for discovery or control. Runtime device communication stays on the LAN. GitHub is used only for package distribution and Software Update version checks.

#### Further notes

Version 0.1.7 was installed from the public archive and validated on OctoPrint 1.6.1 with Python 3.7.3. OctoPrint's forced Software Update check reports the installed and available versions as 0.1.7 and up to date.

Alexa's local Hue integration requires root Hue routes on port 80. On OctoPi, the documented setup keeps HAProxy as the only port 80 listener and selectively forwards the required paths to OctoPrint. The plugin does not modify system services automatically.