### PR TITLE
Add Alexa OctoPrint (revised after #1463)

### DIFF
--- a/_plugins/alexaoctoprint.md
+++ b/_plugins/alexaoctoprint.md
@@ -12,7 +12,7 @@ date: 2026-07-17
 
 homepage: https://github.com/RICLAMER/AlexaOctoPrint
 source: https://github.com/RICLAMER/AlexaOctoPrint
-archive: https://github.com/RICLAMER/AlexaOctoPrint/archive/0.2.0.zip
+archive: https://github.com/RICLAMER/AlexaOctoPrint/releases/latest/download/OctoPrint-AlexaOctoPrint.zip
 
 tags:
 - alexa

--- a/_plugins/alexaoctoprint.md
+++ b/_plugins/alexaoctoprint.md
@@ -1,0 +1,55 @@
+---
+layout: plugin
+
+id: alexaoctoprint
+title: Alexa OctoPrint
+description: Control selected OctoPrint and 3D printer actions through Alexa on the local network without an external backend.
+authors:
+- RICLAMER
+license: AGPL-3.0-or-later
+
+date: 2026-07-17
+
+homepage: https://github.com/RICLAMER/AlexaOctoPrint
+source: https://github.com/RICLAMER/AlexaOctoPrint
+archive: https://github.com/RICLAMER/AlexaOctoPrint/archive/0.2.0.zip
+
+tags:
+- alexa
+- automation
+- control
+- raspberrypi
+
+compatibility:
+  octoprint:
+  - ">=1.6.0"
+  os:
+  - linux
+  python: ">=3.7,<4"
+
+attributes:
+- ai-developed
+
+---
+
+Alexa OctoPrint simulates local smart devices for enabled printer actions. No
+external integration account, Alexa skill, cloud backend, telemetry service, or
+relay is required.
+
+Actions include pause, resume, guarded cancellation, homing, leveling, Z and
+extruder movement, configurable bed and nozzle temperatures, motors, selected
+files, emergency stop, and optional OctoPrint-Enclosure power and light outputs.
+Portuguese, English, and Spanish device names are included.
+
+Local discovery requires restricted root routes on TCP port 80. Existing
+HAProxy or another reverse proxy can provide them. The repository includes an
+explicit Easy Setup that inspects the current listener, preserves unrelated
+routes, validates HAProxy before restart, and saves rollback state. The plugin
+does not silently modify system services.
+
+Each installation generates its own local 40-character username. Proxy ACLs
+match only the description, username creation, and corresponding light paths;
+normal OctoPrint API routes are excluded.
+
+Updates use OctoPrint's `github_release` check and install the archive for the
+matching GitHub release tag.


### PR DESCRIPTION
- [x] You have read the ["Registering a new Plugin"](https://plugins.octoprint.org/help/registering/) guide.
- [x] You want to and are able to maintain the plugin you are registering, long-term.
- [x] You understand why the plugin you are registering works.
- [x] You have read and acknowledge the [Code of Conduct](https://octoprint.org/conduct/).

#### What is the name of your plugin?

Alexa OctoPrint

#### What does your plugin do?

It simulates local smart devices for selected OctoPrint and 3D printer actions. Alexa discovers and controls those actions on the LAN without an external backend, Alexa skill, or integration account. It includes Portuguese, English, and Spanish device names, configurable printer actions, and optional OctoPrint-Enclosure power/light outputs.

#### Where can we find the source code of your plugin?

https://github.com/RICLAMER/AlexaOctoPrint/tree/0.2.0/Source

Tests: https://github.com/RICLAMER/AlexaOctoPrint/tree/0.2.0/tests

Release: https://github.com/RICLAMER/AlexaOctoPrint/releases/tag/0.2.0

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this plugin?

Yes. OpenAI Codex assisted with implementation, tests, debugging, and English documentation. The maintainer defined the requirements and performed iterative testing against a physical Raspberry Pi, OctoPrint installation, Alexa devices, printer, HAProxy, and Enclosure outputs. The registration metadata includes the required `ai-developed` attribute.

#### Is your plugin commercial in nature?

No.

#### Does your plugin rely on some cloud services?

No cloud backend, Alexa skill, account, telemetry service, or relay is used for discovery or control. Runtime device communication stays on the LAN. GitHub is used only for source, releases, installation, and OctoPrint Software Update checks.

#### Changes made after the review in #1463

- Published the complete source and test suite instead of only a distribution ZIP.
- Replaced the previous license with `AGPL-3.0-or-later` and included the full license text.
- Replaced the custom update metadata with OctoPrint's `github_release` configuration and tagged source archives, following the `jneilliii/OctoPrint-BLTouch` pattern.
- Removed the shared static Hue-compatible username. A random 40-character username is generated per installation, validated on light routes, and redacted from logs.
- Restricted HAProxy ACLs by HTTP method and exact local smart-device paths; normal OctoPrint API routes such as `/api/job` and `/api/files` are excluded.
- Added explicit, optional Easy HAProxy Setup with listener detection, backup, validation, rollback, removal, and preservation of unrelated routes. The helper never kills a port owner.
- Simplified the settings UI and removed the temporary test device and mutable network/SSDP controls.
- Added optional Enclosure output dropdowns with controlled unavailable handling when the dependency is absent or disabled.
- Added Espalexa attribution as the protocol research/reference used for local interoperability.

#### Verification

Version 0.2.0 passed 30 automated tests and the gallery front-matter validator with no warnings. The tagged GitHub archive installs as `OctoPrint-AlexaOctoPrint 0.2.0`. It was installed on OctoPrint running Python 3.7.3 and validated on a Raspberry Pi with local Alexa discovery, HAProxy route isolation, and real Enclosure `POWER`/`LIGHT` switching.

This PR replaces the closed #1463.