### PR TITLE
Fix for GitHub stats disappeared from plugin pages (#1466)

### DIFF
--- a/.github/scripts/populate_additional_metadata.py
+++ b/.github/scripts/populate_additional_metadata.py
@@ -52,10 +52,10 @@ GITHUB_GRAPHQL_QUERY = """repository(owner: \"{{user}}\", name: \"{{repo}}\") {
       }
     }
   },
-  watchers(first:1){
+  watchers{
     totalCount
   },
-  stargazers(first:1){
+  stargazers{
     totalCount
   }
 }


### PR DESCRIPTION
This is a proposed workaround for #1466. Fix #1466.

@jneilliii found out that it might be related to https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/. In any case, the bug has been happening for a few days now, so I assume GitHub won't do anything about it.

Note: right now GitHub Actions [are down](https://www.githubstatus.com/incidents/qcvjkzcs7j74), so it may make sense to wait until they are back up before merging this PR.