### PR TITLE
Add Tapo Auto Shutdown plugin

### DIFF
--- a/_plugins/tapoautoshutdown.md
+++ b/_plugins/tapoautoshutdown.md
@@ -1,0 +1,51 @@
+---
+layout: plugin
+
+id: tapoautoshutdown
+title: Tapo Auto Shutdown + Obico Delay
+description: Automatically control a Tapo P110 smart plug and manage Obico AI monitoring around your prints.
+
+#authors:
+#- SpideRaY
+
+license: MIT
+
+date: 2026-09-12
+
+homepage: https://github.com/SpideRaY/OctoPrint-TapoAutoShutdown-ObicoDelay
+source: https://github.com/SpideRaY/OctoPrint-TapoAutoShutdown-ObicoDelay
+archive: https://github.com/SpideRaY/OctoPrint-TapoAutoShutdown-ObicoDelay/archive/refs/tags/v0.2.0.zip
+
+privacypolicy: https://github.com/SpideRaY/OctoPrint-TapoAutoShutdown-ObicoDelay/blob/main/PRIVACY.md
+
+tags:
+tapo
+p110
+smart plug
+power
+shutdown
+obico
+ai
+automation
+print monitoring
+
+compatibility:
+  python: ">=3.9,<3.14"
+
+attributes:
+cloud
+ai-developed
+
+---
+
+Tapo Auto Shutdown automatically switches a Tapo P110 smart plug off after a completed print and can manage Obico AI monitoring during the print.
+
+The plugin provides configurable delays for both Tapo shutdown and Obico AI monitoring. Obico AI monitoring is disabled when a print starts and can be automatically re-enabled after the configured delay if the print is still running.
+
+If the print completes, is cancelled, or fails, the Obico monitoring timer is cancelled and AI monitoring is disabled.
+
+The plugin requires an OctoPrint installation, a Tapo P110 smart plug, the tapo Python package, and the Obico OctoPrint plugin for Obico monitoring features.
+
+The plugin does not modify the printer's operating system or install system services.
+
+For more information, configuration details and source code, see the project repository.


### PR DESCRIPTION
Plugin registration
[x] I have read the "Registering a new Plugin" guide.
[x] I want to and am able to maintain the plugin I'm registering, long-term.
[x] I understand why the plugin I'm registering works.
[x] I have read and acknowledge the Code of Conduct.

#### What is the name of your plugin?

Tapo Auto Shutdown + Obico Delay

#### What does your plugin do?

The plugin automatically controls a Tapo P110 smart plug to shut down power after a completed print. It also integrates with the Obico OctoPrint plugin to disable AI monitoring when a print starts and re-enable it after a configurable delay if the print is still running. This helps reduce unnecessary Obico AI hour usage during the early stages of a print.

#### Where can we find the source code of your plugin?

https://github.com/SpideRaY/OctoPrint-TapoAutoShutdown-ObicoDelay

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this plugin?

Yes. ChatGPT was used to assist with development, debugging and documentation.

#### Is your plugin commercial in nature?

No. The plugin is free and open source.

#### Does your plugin rely on some cloud services?

Yes. The Obico integration communicates with the Obico service through the installed Obico OctoPrint plugin. The Tapo P110 itself is accessed on the user's local network.

#### Further notes

A privacy policy is included in the plugin repository:

https://github.com/SpideRaY/OctoPrint-TapoAutoShutdown-ObicoDelay/blob/main/PRIVACY.md